### PR TITLE
Refactor SectorIndexCalculator into SectorIndex

### DIFF
--- a/project/execution_scripts/current_files/PO48Ensemble_fixed_241014.py
+++ b/project/execution_scripts/current_files/PO48Ensemble_fixed_241014.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import pandas as pd
 from utils.flag_manager import flag_manager, Flags
 from utils.paths import Paths
-from calculation import TargetCalculator, FeaturesCalculator, SectorIndexCalculator
+from calculation import TargetCalculator, FeaturesCalculator, SectorIndex
 from models import MLDataset
 from models.loader import load_datasets
 from models.machine_learning import LassoModel, LgbmModel
@@ -41,8 +41,9 @@ async def read_and_update_data(filter: str) -> dict:
 def get_necessary_dfs(stock_dfs_dict: dict, train_start_day: datetime, train_end_day: datetime, 
                       SECTOR_REDEFINITIONS_CSV: str, SECTOR_INDEX_PARQUET: str) -> dict:
     '''セクターインデックスの計算'''
+    si = SectorIndex()
     new_sector_price_df, order_price_df = \
-        SectorIndexCalculator.calc_sector_index(stock_dfs_dict, SECTOR_REDEFINITIONS_CSV, SECTOR_INDEX_PARQUET)
+        si.calc_sector_index(stock_dfs_dict, SECTOR_REDEFINITIONS_CSV, SECTOR_INDEX_PARQUET)
     '''目的変数の算出'''
     raw_target_df, target_df = \
         TargetCalculator.daytime_return_PCAresiduals(new_sector_price_df,

--- a/project/execution_scripts/current_files/deeplearning_test.py
+++ b/project/execution_scripts/current_files/deeplearning_test.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from utils.paths import Paths #パス一覧
 from acquisition.jquants_api_operations import run_jquants_api_operations
-from calculation import SectorIndexCalculator
+from calculation import SectorIndex
 from models import MLDataset
 import asyncio
 
@@ -42,7 +42,8 @@ async def main(ML_DATASET_PATH:str, NEW_SECTOR_LIST_CSV:str, NEW_SECTOR_PRICE_PK
     list_df, fin_df, price_df = run_jquants_api_operations(filter = universe_filter)
     stock_dfs_dict = {'list': list_df, 'fin': fin_df, 'price': price_df}
 
-    new_sector_price_df, order_price_df = SectorIndexCalculator.calc_sector_index(stock_dfs_dict, NEW_SECTOR_LIST_CSV, NEW_SECTOR_PRICE_PKLGZ)
+    si = SectorIndex()
+    new_sector_price_df, order_price_df = si.calc_sector_index(stock_dfs_dict, NEW_SECTOR_LIST_CSV, NEW_SECTOR_PRICE_PKLGZ)
 
     '''リターン予測→ml_datasetの作成'''
     import torch

--- a/project/execution_scripts/current_files/test.py
+++ b/project/execution_scripts/current_files/test.py
@@ -48,7 +48,7 @@ def prepare_test_data() -> Dict[str, pd.DataFrame]:
     
     # プロジェクト内のモジュールをインポート
     from acquisition.jquants_api_operations.facades.stock_acquisition_facade import StockAcquisitionFacade
-    from calculation.sector_index_calculator import SectorIndexCalculator
+    from calculation.sector_index_calculator import SectorIndex
     from calculation.target_calculator import TargetCalculator
     from calculation.features_calculator import FeaturesCalculator
     from utils.paths import Paths
@@ -69,7 +69,8 @@ def prepare_test_data() -> Dict[str, pd.DataFrame]:
         
         # セクターインデックスの計算
         print("セクターインデックスを計算しています...")
-        sector_index_df, order_price_df = SectorIndexCalculator.calc_sector_index(
+        si = SectorIndex()
+        sector_index_df, order_price_df = si.calc_sector_index(
             stock_dfs, SECTOR_REDEFINITIONS_CSV, SECTOR_INDEX_PARQUET
         )
         

--- a/project/modules/calculation/__init__.py
+++ b/project/modules/calculation/__init__.py
@@ -1,11 +1,11 @@
 from .target_calculator import TargetCalculator
 from .features_calculator import FeaturesCalculator
-from .sector_index_calculator import SectorIndexCalculator
+from .sector_index_calculator import SectorIndex
 from .sector_fin_calculator import SectorFinCalculator
 
 __all__ = [
     'TargetCalculator',
     'FeaturesCalculator',
-    'SectorIndexCalculator',
+    'SectorIndex',
     'SectorFinCalculator'
 ]

--- a/project/modules/calculation/features_calculator.py
+++ b/project/modules/calculation/features_calculator.py
@@ -2,7 +2,7 @@
 from utils.paths import Paths
 import pandas as pd
 from typing import Literal
-from calculation.sector_index_calculator import SectorIndexCalculator
+from calculation.sector_index_calculator import SectorIndex
 
 #%% 関数群
 class FeaturesCalculator:
@@ -245,7 +245,8 @@ class FeaturesCalculator:
         # サイズファクター（業種内の平均サイズファクター）
         if adopt_size_factor:
             new_sector_list['Code'] = new_sector_list['Code'].astype(str)
-            stock_price_cap = SectorIndexCalculator.calc_marketcap(stock_dfs_dict['price'], stock_dfs_dict['fin'])
+            si = SectorIndex()
+            stock_price_cap = si.calc_marketcap(stock_dfs_dict['price'], stock_dfs_dict['fin'])
             stock_price_cap = stock_price_cap[stock_price_cap['Code'].isin(new_sector_list['Code'])]
             stock_price_cap = pd.merge(stock_price_cap, new_sector_list[['Code', 'Sector']], on='Code', how='left')
             stock_price_cap = stock_price_cap[['Date', 'Code', 'Sector', 'MarketCapClose']]
@@ -307,8 +308,9 @@ if __name__ == '__main__':
     universe_filter = \
         "(Listing==1)&((ScaleCategory=='TOPIX Core30')|(ScaleCategory=='TOPIX Large70')|(ScaleCategory=='TOPIX Mid400'))" #現行のTOPIX500
     stock_dfs_dict = StockAcquisitionFacade(filter=universe_filter).get_stock_data_dict()   
+    si = SectorIndex()
     new_sector_price_df, order_price_df = \
-        SectorIndexCalculator.calc_sector_index(stock_dfs_dict, NEW_SECTOR_LIST_CSV, NEW_SECTOR_PRICE_PKLGZ)
+        si.calc_sector_index(stock_dfs_dict, NEW_SECTOR_LIST_CSV, NEW_SECTOR_PRICE_PKLGZ)
     
     new_sector_list = pd.read_csv(NEW_SECTOR_LIST_CSV)
 

--- a/project/modules/calculation/refactored_features_calculator.py
+++ b/project/modules/calculation/refactored_features_calculator.py
@@ -5,7 +5,7 @@ from typing import Literal, List, Optional, Iterable
 from utils.paths import Paths
 from utils.yaml_utils import ColumnConfigsGetter
 from utils.metadata import FeatureMetadata
-from calculation import SectorIndexCalculator
+from calculation import SectorIndex
 from utils import yaml_utils
 
 logging.basicConfig(level=logging.ERROR)
@@ -527,7 +527,7 @@ class FinancialFeatureCalculator:
         eps_df = self._combine_forecast_eps(fin_df)
         # 2) ForecastEPSを銘柄・日付順に並べて ffill
         eps_df = self._ffill_forecast_eps(eps_df)
-        # 3) price_dfから時価総額を計算 (旧コードのSectorIndexCalculatorを利用)
+        # 3) price_dfから時価総額を計算 (旧コードのSectorIndexを利用)
         market_cap_df = self._calculate_marketcap(price_df, fin_df)
         # 4) market_cap_df と eps_df をマージし、欠損を再補完
         merged = self._merge_and_fill(market_cap_df, eps_df)
@@ -568,7 +568,7 @@ class FinancialFeatureCalculator:
 
     def _calculate_marketcap(self, price_df: pd.DataFrame, fin_df: pd.DataFrame) -> pd.DataFrame:
         """
-        旧コードのSectorIndexCalculator.calc_marketcap を用いて、
+        旧コードのSectorIndex.calc_marketcap を用いて、
         price_dfからMarketCapClose列を計算したDataFrameを返す。
 
         Args:
@@ -582,7 +582,8 @@ class FinancialFeatureCalculator:
         if self.is_sector:
             price_df_with_cap = price_df
         else:
-            price_df_with_cap = SectorIndexCalculator.calc_marketcap(price_df, fin_df)
+            si = SectorIndex()
+            price_df_with_cap = si.calc_marketcap(price_df, fin_df)
 
         # marketcap_col が計算された場合、列名を固定 (MarketCapClose) に変更
         if self.sector_col['終値時価総額'] in price_df_with_cap.columns:

--- a/project/modules/calculation/sector_index_calculator.py
+++ b/project/modules/calculation/sector_index_calculator.py
@@ -7,28 +7,32 @@ from datetime import datetime, timedelta
 from typing import Any, Tuple
 
 
-class SectorIndexCalculator:
+class SectorIndex:
     _col_names = None
-    
+
     @staticmethod
     def _get_column_names() -> Tuple[dict, dict, dict]:
-        if SectorIndexCalculator._col_names is None:
+        if SectorIndex._col_names is None:
             fin_col_configs = ColumnConfigsGetter(Paths.STOCK_FIN_COLUMNS_YAML)
             fin_cols = fin_col_configs.get_all_columns_name_asdict()
             price_col_configs = ColumnConfigsGetter(Paths.STOCK_PRICE_COLUMNS_YAML)
             price_cols = price_col_configs.get_all_columns_name_asdict()
             sector_col_configs = ColumnConfigsGetter(Paths.SECTOR_INDEX_COLUMNS_YAML)
             sector_cols = sector_col_configs.get_all_columns_name_asdict()
-            
-            SectorIndexCalculator._col_names = (fin_cols, price_cols, sector_cols)
-        return SectorIndexCalculator._col_names
+
+            SectorIndex._col_names = (fin_cols, price_cols, sector_cols)
+        return SectorIndex._col_names
+
+    def __init__(self) -> None:
+        self.fin_cols, self.price_cols, self.sector_cols = self._get_column_names()
+        self.sector_index_df: pd.DataFrame | None = None
+        self.stock_price_for_order: pd.DataFrame | None = None
 
     # ========================================
     # パブリックメソッド（外部から呼び出し可能）
     # ========================================
 
-    @staticmethod
-    def calc_sector_index(stock_dfs_dict: dict, SECTOR_REDEFINITIONS_CSV: str, SECTOR_INDEX_PARQUET: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def calc_sector_index(self, stock_dfs_dict: dict, SECTOR_REDEFINITIONS_CSV: str, SECTOR_INDEX_PARQUET: str) -> tuple[pd.DataFrame, pd.DataFrame]:
         '''
         セクターインデックスを算出します。
         Args:
@@ -39,18 +43,19 @@ class SectorIndexCalculator:
             pd.DataFrame: セクターインデックスを格納
             pd.DataFrame: 発注用に、個別銘柄の終値と時価総額を格納
         '''
-        _, price_col, sector_col = SectorIndexCalculator._get_column_names()
+        price_col = self.price_cols
+        sector_col = self.sector_cols
         stock_price = stock_dfs_dict['price']
         stock_fin = stock_dfs_dict['fin']
         
         # 価格情報に発行済み株式数の情報を結合
-        stock_price_for_order = SectorIndexCalculator.calc_marketcap(stock_price, stock_fin)
+        stock_price_for_order = self.calc_marketcap(stock_price, stock_fin)
         
         # セクター定義を読み込み、株価データと結合
-        sector_price_data = SectorIndexCalculator._prepare_sector_data_from_csv(stock_price_for_order, SECTOR_REDEFINITIONS_CSV)
+        sector_price_data = self._prepare_sector_data_from_csv(stock_price_for_order, SECTOR_REDEFINITIONS_CSV)
         
         # 共通のインデックス計算処理
-        new_sector_price = SectorIndexCalculator._calculate_sector_aggregation(sector_price_data)
+        new_sector_price = self._calculate_sector_aggregation(sector_price_data)
         
         # データフレームを保存して、インデックスを設定
         new_sector_price = new_sector_price.reset_index()
@@ -58,15 +63,16 @@ class SectorIndexCalculator:
         new_sector_price = new_sector_price.set_index([sector_col['日付'], sector_col['セクター']])
 
         stock_price_for_order = stock_price_for_order[[
-            sector_col['日付'], sector_col['銘柄コード'], sector_col['終値時価総額'], 
+            sector_col['日付'], sector_col['銘柄コード'], sector_col['終値時価総額'],
             sector_col['終値'], price_col['取引高']
         ]]
         print('セクターのインデックス値の算出が完了しました。')
         
+        self.sector_index_df = new_sector_price
+        self.stock_price_for_order = stock_price_for_order
         return new_sector_price, stock_price_for_order
 
-    @staticmethod
-    def calc_sector_index_by_dict(sector_stock_dict: dict, stock_price_data: pd.DataFrame) -> pd.DataFrame:
+    def calc_sector_index_by_dict(self, sector_stock_dict: dict, stock_price_data: pd.DataFrame) -> pd.DataFrame:
         """
         セクター名をキーとし、そのセクターに属する銘柄コードの配列を値とする辞書から
         セクターインデックスを算出します。同じ銘柄コードが複数のセクターに含まれる場合も対応します。
@@ -75,21 +81,20 @@ class SectorIndexCalculator:
             sector_stock_dict (dict): セクター名をキー、銘柄コード配列を値とする辞書
                                     例: {'JPY感応株': ['6758', '6501', '6702'], 
                                         'JPbond感応株': ['6751', '8306', '8316', '8411']}
-            stock_price_data (pd.DataFrame): 株価データ（SectorIndexCalculator.calc_marketcapの出力と同じ構造）
+            stock_price_data (pd.DataFrame): 株価データ（SectorIndex.calc_marketcapの出力と同じ構造）
             
         Returns:
             pd.DataFrame: セクターインデックスのデータフレーム
         """
         # セクター定義を辞書から作成し、株価データと結合
-        sector_price_data = SectorIndexCalculator._prepare_sector_data_from_dict(stock_price_data, sector_stock_dict)
+        sector_price_data = self._prepare_sector_data_from_dict(stock_price_data, sector_stock_dict)
         
         # 共通のインデックス計算処理
-        sector_index = SectorIndexCalculator._calculate_sector_aggregation(sector_price_data)
+        sector_index = self._calculate_sector_aggregation(sector_price_data)
         
         return sector_index
 
-    @staticmethod
-    def calc_marketcap(stock_price: pd.DataFrame, stock_fin: pd.DataFrame) -> pd.DataFrame:
+    def calc_marketcap(self, stock_price: pd.DataFrame, stock_fin: pd.DataFrame) -> pd.DataFrame:
         '''
         各銘柄の日ごとの時価総額を算出する。
         Args:
@@ -99,13 +104,13 @@ class SectorIndexCalculator:
             pd.DataFrame: 価格情報に時価総額を付記
         '''
         # 価格情報に発行済み株式数の情報を照合
-        stock_price_with_shares = SectorIndexCalculator._merge_stock_price_and_shares(stock_price, stock_fin)
+        stock_price_with_shares = self._merge_stock_price_and_shares(stock_price, stock_fin)
         # 発行済み株式数の補正係数を算出
-        stock_price_cap = SectorIndexCalculator._calc_adjustment_factor(stock_price_with_shares, stock_price)
-        stock_price_cap = SectorIndexCalculator._adjust_shares(stock_price_cap)
+        stock_price_cap = self._calc_adjustment_factor(stock_price_with_shares, stock_price)
+        stock_price_cap = self._adjust_shares(stock_price_cap)
         # 時価総額と指数計算用の補正値を算出
-        stock_price_cap = SectorIndexCalculator._calc_marketcap(stock_price_cap)
-        stock_price_cap = SectorIndexCalculator._calc_correction_value(stock_price_cap)
+        stock_price_cap = self._calc_marketcap(stock_price_cap)
+        stock_price_cap = self._calc_correction_value(stock_price_cap)
         
         return stock_price_cap
 
@@ -124,7 +129,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: セクターインデックス
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         
         # セクターごとに集計
         columns_to_sum = [
@@ -146,7 +151,7 @@ class SectorIndexCalculator:
         sector_index[sector_col['終値']] = sector_index.groupby(sector_col['セクター'])[sector_col['終値前日比']].cumprod()
         
         # OHLC計算の共通処理
-        sector_index = SectorIndexCalculator._calculate_ohlc(sector_index)
+        sector_index = SectorIndex._calculate_ohlc(sector_index)
         
         return sector_index
 
@@ -161,7 +166,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: OHLC計算済みのセクターインデックス
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         
         # 始値、高値、安値の計算
         sector_index[sector_col['始値']] = (
@@ -196,7 +201,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: セクター情報が付与された株価データ
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         
         new_sector_list = pd.read_csv(SECTOR_REDEFINITIONS_CSV).dropna(how='any', axis=1)
         new_sector_list[sector_col['銘柄コード']] = new_sector_list[sector_col['銘柄コード']].astype(str)
@@ -216,7 +221,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: セクター情報が付与された株価データ
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         
         # セクター定義を一時的なデータフレームに変換
         sector_definitions = []
@@ -248,11 +253,11 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 価格情報に発行済株式数を付記
         """
-        _, price_col, _ = SectorIndexCalculator._get_column_names()
+        _, price_col, _ = SectorIndex._get_column_names()
         business_days = stock_price[price_col['日付']].unique()
-        shares_df = SectorIndexCalculator._calc_shares_at_end_period(stock_fin)
-        shares_df = SectorIndexCalculator._append_next_period_start_date(shares_df, business_days)
-        merged_df = SectorIndexCalculator._merge_with_stock_price(stock_price, shares_df)
+        shares_df = SectorIndex._calc_shares_at_end_period(stock_fin)
+        shares_df = SectorIndex._append_next_period_start_date(shares_df, business_days)
+        merged_df = SectorIndex._merge_with_stock_price(stock_price, shares_df)
         return merged_df
 
     @staticmethod
@@ -264,7 +269,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 財務情報に発行済株式数を付記
         """
-        fin_col, _, _  = SectorIndexCalculator._get_column_names()
+        fin_col, _, _  = SectorIndex._get_column_names()
         shares_df = stock_fin[[fin_col['銘柄コード'], fin_col['日付'], fin_col['発行済み株式数'], fin_col['当会計期間終了日']]].copy()
         shares_df = shares_df.sort_values(fin_col['日付']).drop(fin_col['日付'], axis=1)
         shares_df = shares_df.drop_duplicates(subset=[fin_col['当会計期間終了日'], fin_col['銘柄コード']], keep='last')
@@ -283,7 +288,7 @@ class SectorIndexCalculator:
             pd.DataFrame: 財務情報に発行済株式数と時期開始日を付記
         """
         shares_df['NextPeriodStartDate'] = shares_df['NextPeriodStartDate'].apply(
-            SectorIndexCalculator._find_next_business_day, business_days=business_days
+            SectorIndex._find_next_business_day, business_days=business_days
         )
         return shares_df
 
@@ -313,7 +318,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 結合されたデータフレーム
         """
-        fin_col, price_col, sector_col = SectorIndexCalculator._get_column_names()
+        fin_col, price_col, sector_col = SectorIndex._get_column_names()
         stock_price = stock_price.rename(columns={price_col['銘柄コード']: sector_col['銘柄コード'], price_col['日付']: sector_col['日付']})
         shares_df = shares_df.rename(columns={fin_col['銘柄コード']: sector_col['銘柄コード'], 'NextPeriodStartDate': sector_col['日付']})
 
@@ -343,12 +348,12 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 調整後の価格情報データフレーム
         """
-        stock_price_to_adjust = SectorIndexCalculator._extract_rows_to_adjust(stock_price_with_shares)
-        stock_price_to_adjust = SectorIndexCalculator._calc_shares_rate(stock_price_to_adjust)
-        adjusted_stock_price = SectorIndexCalculator._correct_shares_rate_for_non_adjustment(stock_price_to_adjust)
-        stock_price = SectorIndexCalculator._merge_shares_rate(stock_price, adjusted_stock_price)
-        stock_price = SectorIndexCalculator._handle_special_cases(stock_price)
-        return SectorIndexCalculator._calc_cumulative_shares_rate(stock_price)
+        stock_price_to_adjust = SectorIndex._extract_rows_to_adjust(stock_price_with_shares)
+        stock_price_to_adjust = SectorIndex._calc_shares_rate(stock_price_to_adjust)
+        adjusted_stock_price = SectorIndex._correct_shares_rate_for_non_adjustment(stock_price_to_adjust)
+        stock_price = SectorIndex._merge_shares_rate(stock_price, adjusted_stock_price)
+        stock_price = SectorIndex._handle_special_cases(stock_price)
+        return SectorIndex._calc_cumulative_shares_rate(stock_price)
 
     @staticmethod
     def _extract_rows_to_adjust(stock_price_with_shares_df: pd.DataFrame) -> pd.DataFrame:
@@ -359,7 +364,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 引数のdfから株式分割・併合対象行のみを抽出
         """
-        _, price_col, sector_col = SectorIndexCalculator._get_column_names()
+        _, price_col, sector_col = SectorIndex._get_column_names()
         condition = (stock_price_with_shares_df[sector_col['発行済み株式数']].notnull() | (stock_price_with_shares_df[price_col['調整係数']] != 1))
         return stock_price_with_shares_df.loc[condition].copy()
 
@@ -372,7 +377,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 発行済み株式数の比率を計算したデータフレーム
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         df[sector_col['発行済み株式数']] = df.groupby(sector_col['銘柄コード'])[sector_col['発行済み株式数']].bfill()
         df['SharesRate'] = (df.groupby(sector_col['銘柄コード'])[sector_col['発行済み株式数']].shift(-1) / df[sector_col['発行済み株式数']]).round(1)
         return df
@@ -386,7 +391,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 調整後のデータフレーム
         """
-        _, price_col, sector_col = SectorIndexCalculator._get_column_names()
+        _, price_col, sector_col = SectorIndex._get_column_names()
         # 補正係数の出るタイミングと実際に補正の必要なタイミングが±2データぶんずれる場合がある。
         shift_days = [1, 2, -1, -2]
         shift_columns = [f'Shift_AdjustmentFactor{i}' for i in shift_days]
@@ -405,7 +410,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 価格情報に発行済株式数比率を併記
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         df_to_calc_shares_rate = df_to_calc_shares_rate[df_to_calc_shares_rate['isSettlementDay']]
         df_to_calc_shares_rate['SharesRate'] = df_to_calc_shares_rate.groupby(sector_col['銘柄コード'])['SharesRate'].shift(1)
         stock_price = pd.merge(
@@ -427,7 +432,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 補正後のデータフレーム
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         stock_price.loc[(stock_price[sector_col['銘柄コード']] == '3064') & (stock_price[sector_col['日付']] <= datetime(2013, 7, 25)), 'SharesRate'] = 1
         stock_price.loc[(stock_price[sector_col['銘柄コード']] == '6920') & (stock_price[sector_col['日付']] <= datetime(2013, 8, 9)), 'SharesRate'] = 1
         return stock_price
@@ -441,7 +446,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 累積積を計算したデータフレーム
         """
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         stock_price = stock_price.sort_values(sector_col['日付'], ascending=False)
         stock_price['CumulativeSharesRate'] = stock_price.groupby(sector_col['銘柄コード'])['SharesRate'].cumprod()
         stock_price = stock_price.sort_values(sector_col['日付'], ascending=True)
@@ -457,7 +462,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 引数のdfの発行済株式数を補正したもの
         '''
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         #決算発表時以外が欠測値なので、後埋めする。
         df[sector_col['発行済み株式数']] = df.groupby(sector_col['銘柄コード'], as_index=False)[sector_col['発行済み株式数']].ffill() 
         #初回決算発表以前の分を前埋め。
@@ -479,7 +484,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 引数のdfに時価総額のOHLCを追加したもの
         '''
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         df[sector_col['始値時価総額']] = df[sector_col['始値']] * df[sector_col['発行済み株式数']]
         df[sector_col['終値時価総額']] = df[sector_col['終値']] * df[sector_col['発行済み株式数']]
         df[sector_col['高値時価総額']] = df[sector_col['高値']] * df[sector_col['発行済み株式数']]
@@ -495,7 +500,7 @@ class SectorIndexCalculator:
         Returns:
             pd.DataFrame: 引数のdfに指数算出補正値を併記したもの
         '''
-        _, _, sector_col = SectorIndexCalculator._get_column_names()
+        _, _, sector_col = SectorIndex._get_column_names()
         df['OutstandingShares_forCorrection'] = \
             df.groupby( sector_col['銘柄コード'])[sector_col['発行済み株式数']].shift(1)
         df['OutstandingShares_forCorrection'] = df['OutstandingShares_forCorrection'].fillna(0)
@@ -509,7 +514,7 @@ if __name__ == '__main__':
     acq = StockAcquisitionFacade(filter = "(Listing==1)&((ScaleCategory=='TOPIX Core30')|(ScaleCategory=='TOPIX Large70')|(ScaleCategory=='TOPIX Mid400')|(ScaleCategory=='TOPIX Small 1'))")
     stock_dfs = acq.get_stock_data_dict()
 
-    sic = SectorIndexCalculator()
+    sic = SectorIndex()
     sector_price_df, order_price_df = sic.calc_sector_index(stock_dfs, 
                                             f'{Paths.SECTOR_REDEFINITIONS_FOLDER}/topix1000.csv', 
                                             f'{Paths.SECTOR_REDEFINITIONS_FOLDER}/TOPIX1000_price.parquet')

--- a/project/modules/calculation/test.py
+++ b/project/modules/calculation/test.py
@@ -15,7 +15,7 @@ from calculation.features_calculator import FeaturesCalculator as OldFeaturesCal
 from calculation.refactored_features_calculator import main as new_features_calculator_main
 from acquisition.jquants_api_operations.facades.stock_acquisition_facade import StockAcquisitionFacade
 from utils.paths import Paths
-from calculation.sector_index_calculator import SectorIndexCalculator
+from calculation.sector_index_calculator import SectorIndex
 
 
 def compare_dataframes(old_df, new_df, name=""):
@@ -125,7 +125,8 @@ def test_features_calculator():
     NEW_SECTOR_PRICE_PKLGZ = f'{Paths.SECTOR_REDEFINITIONS_FOLDER}/sector_price/New48sectors_price.parquet'
     
     # セクター価格の計算（両方のテストで共通利用）
-    new_sector_price_df, _ = SectorIndexCalculator.calc_sector_index(
+    si = SectorIndex()
+    new_sector_price_df, _ = si.calc_sector_index(
         stock_dfs, SECTOR_REDEFINITIONS_CSV, NEW_SECTOR_PRICE_PKLGZ)
     new_sector_list = pd.read_csv(SECTOR_REDEFINITIONS_CSV)
 

--- a/project/modules/data_processing/facades/legacy_features_facade.py
+++ b/project/modules/data_processing/facades/legacy_features_facade.py
@@ -8,7 +8,7 @@ import warnings
 
 # 既存クラスのインポート
 from calculation.features_calculator import FeaturesCalculator
-from calculation.sector_index_calculator import SectorIndexCalculator
+from calculation.sector_index_calculator import SectorIndex
 
 # 新システムのインポート
 from data_processing.core.return_calculators import get_return_calculator
@@ -236,8 +236,9 @@ class LegacyFeaturesFacade:
         if kwargs.get('adopt_size_factor', True):
             try:
                 new_sector_list['Code'] = new_sector_list['Code'].astype(str)
-                stock_price_cap = SectorIndexCalculator.calc_marketcap(
-                    stock_dfs_dict['price'], 
+                si = SectorIndex()
+                stock_price_cap = si.calc_marketcap(
+                    stock_dfs_dict['price'],
                     stock_dfs_dict['fin']
                 )
                 stock_price_cap = stock_price_cap[stock_price_cap['Code'].isin(new_sector_list['Code'])]

--- a/tests/test_sector_index.py
+++ b/tests/test_sector_index.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from calculation import SectorIndex
+
+def test_sector_index_by_dict_simple():
+    si = SectorIndex()
+    price_col = si.price_cols
+    fin_col = si.fin_cols
+    sector_col = si.sector_cols
+
+    stock_price = pd.DataFrame({
+        price_col['日付']: pd.to_datetime(['2020-01-01', '2020-01-02']),
+        price_col['銘柄コード']: ['1111', '1111'],
+        price_col['始値']: [100, 110],
+        price_col['高値']: [110, 115],
+        price_col['安値']: [90, 105],
+        price_col['終値']: [105, 108],
+        price_col['調整係数']: [1, 1],
+        price_col['取引高']: [1000, 1100],
+    })
+
+    stock_fin = pd.DataFrame({
+        fin_col['銘柄コード']: ['1111'],
+        fin_col['日付']: pd.to_datetime(['2019-12-31']),
+        fin_col['発行済み株式数']: [100000],
+        fin_col['当会計期間終了日']: pd.to_datetime(['2019-12-31']),
+    })
+
+    marketcap_df = si.calc_marketcap(stock_price, stock_fin)
+    sector_index = si.calc_sector_index_by_dict({'Test': ['1111']}, marketcap_df)
+
+    assert not sector_index.empty
+    assert sector_col['終値'] in sector_index.columns


### PR DESCRIPTION
## Summary
- rename `SectorIndexCalculator` to `SectorIndex`
- update public methods to instance methods and keep column names on the instance
- adjust all imports and usages for the new class name
- keep debug script functional under the new name
- add a minimal pytest verifying index calculation

## Testing
- `pytest -q` *(fails: pyenv couldn't find python version and pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68419c396b908332bf43c538c19894fe