### PR TITLE
Enable borrowing stock info in orders

### DIFF
--- a/project/modules/trading/sbi/orders/ordermaker/batch_order_maker.py
+++ b/project/modules/trading/sbi/orders/ordermaker/batch_order_maker.py
@@ -50,6 +50,7 @@ class BatchOrderMaker(OrderMaker):
                 unit=row['Unit'] * 100,
                 direction=row['Direction'],
                 estimated_price=row['EstimatedCost'] / 100,  # 単価を計算
+                is_borrowing_stock=bool(row.get("isBorrowingStock", False)),
                 order_type='成行',
                 period_type="当日中",
                 trade_section="特定預り"


### PR DESCRIPTION
## Summary
- propagate `isBorrowingStock` from stock selection to order request

## Testing
- `pytest -q` *(fails: pyenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684272ebd4f88332a2df3e73b28d9317