### PR TITLE
Add DatasetLoader class for grouped dataset utilities

### DIFF
--- a/project/execution_scripts/current_files/test.py
+++ b/project/execution_scripts/current_files/test.py
@@ -137,7 +137,6 @@ def run_original_ensemble(test_data: Dict[str, pd.DataFrame]) -> Dict[str, Any]:
     from models import MLDataset
     from models.machine_learning import LassoModel, LgbmModel
     import models.ensemble as ensembles
-    from models.loader import load_datasets
     
     # テスト用のパス
     ML_DATASET_PATH1 = os.path.join(TEST_DIR, 'original', 'lasso_model')

--- a/project/modules/models/__init__.py
+++ b/project/modules/models/__init__.py
@@ -1,6 +1,11 @@
 from .machine_learning import (
-    LassoModel, LgbmModel, EnsembleMethodFactory, MLDatasets, SingleMLDataset
-    )
+    LassoModel,
+    LgbmModel,
+    EnsembleMethodFactory,
+    MLDatasets,
+    SingleMLDataset,
+)
+from .loader import DatasetLoader
 
 __all__ = [
     'MLDatasets',
@@ -8,4 +13,5 @@ __all__ = [
     'LassoModel',
     'LgbmModel',
     'EnsembleMethodFactory',
+    'DatasetLoader',
 ]

--- a/project/modules/models/loader.py
+++ b/project/modules/models/loader.py
@@ -1,0 +1,83 @@
+import os
+from datetime import datetime
+from typing import List, Optional
+
+import pandas as pd
+
+from .machine_learning import MLDatasets, SingleMLDataset
+
+
+class DatasetLoader:
+    """``MLDatasets`` の作成・読み込みをまとめたユーティリティクラス."""
+
+    def __init__(self, dataset_root: str, *, group_level: str = "Sector") -> None:
+        self.dataset_root = dataset_root
+        self.group_level = group_level
+
+    def create_grouped_datasets(
+        self,
+        target_df: pd.DataFrame,
+        features_df: pd.DataFrame,
+        train_start_day: datetime,
+        train_end_day: datetime,
+        test_start_day: datetime,
+        test_end_day: datetime,
+        *,
+        outlier_threshold: float = 0.0,
+        raw_target_df: Optional[pd.DataFrame] = None,
+        order_price_df: Optional[pd.DataFrame] = None,
+        no_shift_features: Optional[List[str]] = None,
+        reuse_features_df: bool = False,
+    ) -> MLDatasets:
+        """グループ単位で ``SingleMLDataset`` を作成し ``MLDatasets`` として保存する。"""
+        if no_shift_features is None:
+            no_shift_features = []
+
+        ml_datasets = MLDatasets()
+        os.makedirs(self.dataset_root, exist_ok=True)
+
+        groups = target_df.index.get_level_values(self.group_level).unique()
+        for group in groups:
+            target_single = target_df[target_df.index.get_level_values(self.group_level) == group]
+            features_single = features_df[features_df.index.get_level_values(self.group_level) == group]
+            single_path = os.path.join(self.dataset_root, str(group))
+            single_ds = SingleMLDataset(single_path, str(group), init_load=False)
+            single_ds.archive_train_test_data(
+                target_df=target_single,
+                features_df=features_single,
+                train_start_day=train_start_day,
+                train_end_day=train_end_day,
+                test_start_day=test_start_day,
+                test_end_day=test_end_day,
+                outlier_threshold=outlier_threshold,
+                no_shift_features=no_shift_features,
+                reuse_features_df=reuse_features_df,
+            )
+            if raw_target_df is not None:
+                single_ds.archive_raw_target(raw_target_df)
+            if order_price_df is not None:
+                single_ds.archive_order_price(order_price_df)
+            ml_datasets.append_model(single_ds)
+
+        ml_datasets.save_all()
+        return ml_datasets
+
+    def load_datasets(self, names: Optional[List[str]] = None) -> MLDatasets:
+        """保存済み ``SingleMLDataset`` 群から ``MLDatasets`` を復元する."""
+        ml_datasets = MLDatasets()
+        if not os.path.isdir(self.dataset_root):
+            raise FileNotFoundError(f"{self.dataset_root} が存在しません")
+
+        for name in sorted(os.listdir(self.dataset_root)):
+            if names is not None and name not in names:
+                continue
+            path = os.path.join(self.dataset_root, name)
+            if os.path.isdir(path):
+                ml_datasets.append_model(SingleMLDataset(path, name))
+        return ml_datasets
+
+
+# 以下のラッパー関数は、過去の互換性のために残していたが、
+# ``DatasetLoader`` を直接利用することで同等の処理が可能なため削除した。
+
+


### PR DESCRIPTION
## Summary
- replace loader utility functions with new `DatasetLoader` class
- expose `DatasetLoader` via `models` package
- remove obsolete helper wrappers

## Testing
- `pytest -q` *(fails: pyenv / pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842b1a230b88332a0309dbaf44085e4