### PR TITLE
Add interactive dendrogram to clustering notebook

### DIFF
--- a/project/execution_scripts/clustering/sector_redim_UMAP.ipynb
+++ b/project/execution_scripts/clustering/sector_redim_UMAP.ipynb
@@ -1275,6 +1275,24 @@
     "result_df.to_csv('cluster_hdbscan.csv')\n",
     "result_df"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.figure_factory as ff\n",
+    "\n",
+    "cluster_cols = [c for c in result_df.columns if c.startswith('Level') or c=='Cluster']\n",
+    "fig = ff.create_dendrogram(\n",
+    "    result_df[cluster_cols].fillna(-1).values,\n",
+    "    labels=result_df.index.astype(str).tolist(),\n",
+    "    orientation='left'\n",
+    ")\n",
+    "fig.update_layout(width=1000, height=600)\n",
+    "fig.show()\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- switch dendrogram cell to Plotly for interactive visualization

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68459d2a7f8c8332977432e3eece9e62