### PR TITLE
Add modular facades and pipeline script

### DIFF
--- a/project/execution_scripts/current_files/PO48Ensemble_facade_pipeline.py
+++ b/project/execution_scripts/current_files/PO48Ensemble_facade_pipeline.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+import asyncio
+
+from utils.notifier import SlackNotifier
+from utils.paths import Paths
+from facades import (
+    DataUpdateFacade,
+    MachineLearningFacade,
+    OrderExecutionFacade,
+    TradeDataFacade,
+)
+from trading import TradingFacade
+
+
+async def main() -> None:
+    slack = SlackNotifier(program_name=os.path.basename(__file__))
+    slack.start(message='プログラムを開始します。', should_send_program_name=True)
+
+    # パラメータ設定
+    sector_redef_csv = f"{Paths.SECTOR_REDEFINITIONS_FOLDER}/48sectors_2024-2025.csv"
+    sector_index_parquet = f"{Paths.SECTOR_PRICE_FOLDER}/New48sectors_price.parquet"
+    dataset_path1 = f"{Paths.ML_DATASETS_FOLDER}/48sectors_LASSO_learned_in_250607"
+    dataset_path2 = f"{Paths.ML_DATASETS_FOLDER}/48sectors_LightGBMlearned_in_250607"
+    ensembled_dataset_path = f"{Paths.ML_DATASETS_FOLDER}/48sectors_Ensembled_learned_in_250607"
+    universe_filter = "(Listing==1)&((ScaleCategory=='TOPIX Core30')|(ScaleCategory=='TOPIX Large70')|(ScaleCategory=='TOPIX Mid400'))"
+    trading_sector_num = 3
+    candidate_sector_num = 5
+    top_slope = 1
+    train_start_day = datetime(2014, 1, 1)
+    train_end_day = datetime(2024, 12, 31)
+    test_start_day = datetime(2014, 1, 1)
+    test_end_day = datetime(2099, 12, 31)
+
+    try:
+        # 1. データ更新
+        data_facade = DataUpdateFacade('update_and_load', universe_filter)
+        stock_dict = await data_facade.execute()
+
+        # 2. 機械学習
+        ml_facade = MachineLearningFacade(
+            'train_and_predict',
+            dataset_path1,
+            dataset_path2,
+            ensembled_dataset_path,
+            sector_redef_csv,
+            sector_index_parquet,
+            train_start_day,
+            train_end_day,
+            test_start_day,
+            test_end_day,
+        )
+        ml_dataset = await ml_facade.execute(stock_dict)
+
+        # 3. 発注
+        trading_facade = TradingFacade()
+        order_facade = OrderExecutionFacade(
+            'new',
+            trading_facade,
+            sector_redef_csv,
+            trading_sector_num,
+            candidate_sector_num,
+            top_slope,
+        )
+        await order_facade.execute(ml_dataset)
+
+        # 4. 取引データの取得
+        trade_data_facade = TradeDataFacade('fetch', trading_facade, sector_redef_csv)
+        await trade_data_facade.execute()
+
+        slack.finish(message='すべての処理が完了しました。')
+    except Exception:
+        from utils.error_handler import error_handler
+        error_handler.handle_exception(Paths.ERROR_LOG_CSV)
+        error_handler.handle_exception(Paths.ERROR_LOG_BACKUP)
+        slack.send_error_log(f"エラーが発生しました。\n詳細は{Paths.ERROR_LOG_CSV}を確認してください。")
+
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())
+

--- a/project/modules/facades/__init__.py
+++ b/project/modules/facades/__init__.py
@@ -1,7 +1,15 @@
 from .evaluation_facade import EvaluationFacade
 from .sector_ml_datasets_facade import SectorMLDatasetsFacade
+from .data_pipeline.data_update_facade import DataUpdateFacade
+from .data_pipeline.machine_learning_facade import MachineLearningFacade
+from .data_pipeline.order_execution_facade import OrderExecutionFacade
+from .data_pipeline.trade_data_facade import TradeDataFacade
 
 __all__ = [
     'EvaluationFacade',
     'SectorMLDatasetsFacade',
+    'DataUpdateFacade',
+    'MachineLearningFacade',
+    'OrderExecutionFacade',
+    'TradeDataFacade',
 ]

--- a/project/modules/facades/data_pipeline/__init__.py
+++ b/project/modules/facades/data_pipeline/__init__.py
@@ -1,0 +1,12 @@
+from .data_update_facade import DataUpdateFacade
+from .machine_learning_facade import MachineLearningFacade
+from .order_execution_facade import OrderExecutionFacade
+from .trade_data_facade import TradeDataFacade
+
+__all__ = [
+    'DataUpdateFacade',
+    'MachineLearningFacade',
+    'OrderExecutionFacade',
+    'TradeDataFacade',
+]
+

--- a/project/modules/facades/data_pipeline/data_update_facade.py
+++ b/project/modules/facades/data_pipeline/data_update_facade.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Literal
+import pandas as pd
+
+from acquisition.jquants_api_operations import StockAcquisitionFacade
+from acquisition.features_updater.facades import FeaturesUpdateFacade
+
+
+class DataUpdateFacade:
+    """Facade for updating and loading data."""
+
+    def __init__(self, mode: Literal['update_and_load', 'load_only', 'none'], universe_filter: str) -> None:
+        self.mode = mode
+        self.universe_filter = universe_filter
+
+    async def execute(self) -> Optional[Dict[str, pd.DataFrame]]:
+        if self.mode == 'none':
+            return None
+        update = self.mode == 'update_and_load'
+        process = update
+        stock_dict = StockAcquisitionFacade(update=update, process=process, filter=self.universe_filter).get_stock_data_dict()
+        if update:
+            fu = FeaturesUpdateFacade()
+            await fu.update_all()
+        return stock_dict

--- a/project/modules/facades/data_pipeline/machine_learning_facade.py
+++ b/project/modules/facades/data_pipeline/machine_learning_facade.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional, Literal
+import pandas as pd
+
+from calculation import TargetCalculator, FeaturesCalculator, SectorIndex
+from models.machine_learning.ml_dataset import MLDatasets, SingleMLDataset
+from models.machine_learning.ensembles import EnsembleMethodFactory
+from models.machine_learning.models import LassoModel, LgbmModel
+from models.machine_learning.loaders import DatasetLoader
+
+
+class MachineLearningFacade:
+    """Facade for training and predicting models."""
+
+    def __init__(
+        self,
+        mode: Literal['train_and_predict', 'predict_only', 'none'],
+        dataset_path1: str,
+        dataset_path2: str,
+        ensembled_dataset_path: str,
+        sector_redef_csv: str,
+        sector_index_parquet: str,
+        train_start_day: datetime,
+        train_end_day: datetime,
+        test_start_day: datetime,
+        test_end_day: datetime,
+    ) -> None:
+        self.mode = mode
+        self.dataset_path1 = dataset_path1
+        self.dataset_path2 = dataset_path2
+        self.ensembled_dataset_path = ensembled_dataset_path
+        self.sector_redef_csv = sector_redef_csv
+        self.sector_index_parquet = sector_index_parquet
+        self.train_start_day = train_start_day
+        self.train_end_day = train_end_day
+        self.test_start_day = test_start_day
+        self.test_end_day = test_end_day
+
+    def _get_necessary_dfs(self, stock_dfs_dict: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
+        sic = SectorIndex(stock_dfs_dict, self.sector_redef_csv, self.sector_index_parquet)
+        new_sector_price_df, order_price_df = sic.calc_sector_index()
+        raw_target_df, target_df = TargetCalculator.daytime_return_PCAresiduals(
+            new_sector_price_df,
+            reduce_components=1,
+            train_start_day=self.train_start_day,
+            train_end_day=self.train_end_day,
+        )
+        return {
+            'new_sector_price_df': new_sector_price_df,
+            'order_price_df': order_price_df,
+            'raw_target_df': raw_target_df,
+            'target_df': target_df,
+        }
+
+    def _update_1st_model(self, necessary: Dict[str, pd.DataFrame]) -> MLDatasets:
+        dsl = DatasetLoader(self.dataset_path1)
+        target_df = necessary['target_df']
+        if self.mode == 'train_and_predict':
+            features_df = FeaturesCalculator.calculate_features(
+                necessary['new_sector_price_df'],
+                None,
+                None,
+                adopts_features_indices=True,
+                adopts_features_price=False,
+                groups_setting=None,
+                names_setting=None,
+                currencies_type='relative',
+                adopt_1d_return=True,
+                mom_duration=None,
+                vola_duration=None,
+                adopt_size_factor=False,
+                adopt_eps_factor=False,
+                adopt_sector_categorical=False,
+                add_rank=False,
+            )
+            ml_datasets = dsl.create_grouped_datasets(
+                target_df,
+                features_df,
+                self.train_start_day,
+                self.train_end_day,
+                self.test_start_day,
+                self.test_end_day,
+                raw_target_df=necessary['raw_target_df'],
+                order_price_df=necessary['order_price_df'],
+                outlier_threshold=3,
+            )
+        else:
+            ml_datasets = dsl.load_datasets()
+
+        lasso_model = LassoModel()
+        for key, single_ml in ml_datasets.items():
+            if self.mode == 'train_and_predict':
+                trainer_outputs = lasso_model.train(
+                    single_ml.train_test_materials.target_train_df,
+                    single_ml.train_test_materials.features_train_df,
+                )
+                single_ml.archive_ml_objects(trainer_outputs.model, trainer_outputs.scaler)
+            pred_result_df = lasso_model.predict(
+                single_ml.train_test_materials.target_test_df,
+                single_ml.train_test_materials.features_test_df,
+                single_ml.ml_object_materials.model,
+                single_ml.ml_object_materials.scaler,
+            )
+            single_ml.archive_pred_result(pred_result_df)
+            single_ml.save()
+        return ml_datasets
+
+    def _update_2nd_model(self, ml_datasets1: MLDatasets, stock_dfs_dict: Dict[str, pd.DataFrame], necessary: Dict[str, pd.DataFrame]) -> MLDatasets:
+        dsl = DatasetLoader(self.dataset_path2)
+        ml_datasets2 = dsl.load_datasets()
+        for key, single_ml in ml_datasets2.items():
+            if self.mode == 'train_and_predict':
+                features_df = FeaturesCalculator.calculate_features(
+                    necessary['new_sector_price_df'],
+                    pd.read_csv(self.sector_redef_csv),
+                    stock_dfs_dict,
+                    adopts_features_indices=True,
+                    adopts_features_price=True,
+                    groups_setting=None,
+                    names_setting=None,
+                    currencies_type='relative',
+                    adopt_1d_return=True,
+                    mom_duration=[5, 21],
+                    vola_duration=[5, 21],
+                    adopt_size_factor=True,
+                    adopt_eps_factor=True,
+                    adopt_sector_categorical=True,
+                    add_rank=True,
+                )
+                pred_in_1st_model = ml_datasets1.get_pred_result()
+                features_df = pd.merge(
+                    features_df,
+                    pred_in_1st_model[['Pred']],
+                    how='outer',
+                    left_index=True,
+                    right_index=True,
+                )
+                features_df = features_df.rename(columns={'Pred': '1stModel_pred'})
+                single_ml.archive_train_test_data(
+                    necessary['target_df'],
+                    features_df,
+                    self.train_start_day,
+                    self.train_end_day,
+                    self.test_start_day,
+                    self.test_end_day,
+                    outlier_threshold=3,
+                    no_shift_features=['1stModel_pred'],
+                    reuse_features_df=True,
+                )
+                single_ml.archive_raw_target(necessary['raw_target_df'])
+                single_ml.archive_order_price(necessary['order_price_df'])
+
+            lgbm_model = LgbmModel()
+            if self.mode == 'train_and_predict':
+                trainer_outputs = lgbm_model.train(
+                    single_ml.train_test_materials.target_train_df,
+                    single_ml.train_test_materials.features_train_df,
+                    categorical_features=['Sector_cat'],
+                )
+                single_ml.archive_ml_objects(model=trainer_outputs.model, scaler=None)
+            pred_result_df = lgbm_model.predict(
+                single_ml.train_test_materials.target_test_df,
+                single_ml.train_test_materials.features_test_df,
+                single_ml.ml_object_materials.model,
+            )
+            single_ml.archive_pred_result(pred_result_df)
+            ml_datasets2.append_model(single_ml)
+            ml_datasets2.save_all()
+            return ml_datasets2
+
+    def _ensemble(self, pred1: pd.DataFrame, pred2: pd.DataFrame) -> pd.DataFrame:
+        emf = EnsembleMethodFactory()
+        rank_method = emf.create_method('by_rank')
+        return rank_method.ensemble([(pred1, 6.7), (pred2, 1.3)])
+
+    def _update_ensembled(self, ensembled_pred_df: pd.DataFrame) -> SingleMLDataset:
+        single = SingleMLDataset(self.ensembled_dataset_path, 'Ensembled')
+        single.archive_pred_result(ensembled_pred_df)
+        single.save()
+        return single
+
+    async def execute(self, stock_dfs_dict: Dict[str, pd.DataFrame]) -> Optional[SingleMLDataset]:
+        if self.mode == 'none':
+            return None
+        necessary = self._get_necessary_dfs(stock_dfs_dict)
+        ml_dataset1 = self._update_1st_model(necessary)
+        ml_dataset2 = self._update_2nd_model(ml_dataset1, stock_dfs_dict, necessary)
+        pred1 = ml_dataset1.get_pred_result()
+        pred2 = ml_dataset2.get_pred_result()
+        ensembled = self._ensemble(pred1, pred2)
+        ml_dataset_ensembled = self._update_ensembled(ensembled)
+        return ml_dataset_ensembled
+

--- a/project/modules/facades/data_pipeline/order_execution_facade.py
+++ b/project/modules/facades/data_pipeline/order_execution_facade.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from models.machine_learning.ml_dataset import SingleMLDataset
+from trading import TradingFacade
+
+
+class OrderExecutionFacade:
+    """Facade for executing trading orders."""
+
+    def __init__(
+        self,
+        mode: Literal['new', 'additional', 'settle', 'none'],
+        trade_facade: TradingFacade,
+        sector_csv: str,
+        trading_sector_num: int,
+        candidate_sector_num: int,
+        top_slope: float,
+    ) -> None:
+        self.mode = mode
+        self.trade_facade = trade_facade
+        self.sector_csv = sector_csv
+        self.trading_sector_num = trading_sector_num
+        self.candidate_sector_num = candidate_sector_num
+        self.top_slope = top_slope
+
+    async def execute(self, ml_dataset: Optional[SingleMLDataset]) -> None:
+        if self.mode == 'none' or ml_dataset is None:
+            return
+        if self.mode == 'new':
+            materials = ml_dataset.post_processing_data.getter_stock_selection()
+            await self.trade_facade.take_positions(
+                order_price_df=materials.order_price_df,
+                pred_result_df=materials.pred_result_df,
+                SECTOR_REDEFINITIONS_CSV=self.sector_csv,
+                num_sectors_to_trade=self.trading_sector_num,
+                num_candidate_sectors=self.candidate_sector_num,
+                top_slope=self.top_slope,
+            )
+        elif self.mode == 'additional':
+            await self.trade_facade.take_additionals_until_completed()
+        elif self.mode == 'settle':
+            await self.trade_facade.settle_positions()
+

--- a/project/modules/facades/data_pipeline/trade_data_facade.py
+++ b/project/modules/facades/data_pipeline/trade_data_facade.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from trading import TradingFacade
+
+
+class TradeDataFacade:
+    """Facade for fetching trading data."""
+
+    def __init__(self, mode: Literal['fetch', 'none'], trade_facade: TradingFacade, sector_csv: str) -> None:
+        self.mode = mode
+        self.trade_facade = trade_facade
+        self.sector_csv = sector_csv
+
+    async def execute(self) -> None:
+        if self.mode == 'fetch':
+            await self.trade_facade.fetch_invest_result(self.sector_csv)
+


### PR DESCRIPTION
## Summary
- add a set of facades for data update, ML, order execution and result fetch
- create a pipeline script that wires the facades together

## Testing
- `python3 -m py_compile project/modules/facades/data_pipeline/*.py project/execution_scripts/current_files/PO48Ensemble_facade_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684778df385c8332b22721d91d199319