### PR TITLE
Add ModeCollection with automatic mode adjustment

### DIFF
--- a/project/modules/facades/mode_setting/__init__.py
+++ b/project/modules/facades/mode_setting/__init__.py
@@ -1,0 +1,13 @@
+from .mode_collection import (
+    OrderExecutionMode,
+    MachineLearningMode,
+    DataUpdateMode,
+    ModeCollection,
+)
+
+__all__ = [
+    'OrderExecutionMode',
+    'MachineLearningMode',
+    'DataUpdateMode',
+    'ModeCollection',
+]

--- a/project/modules/facades/mode_setting/mode_collection.py
+++ b/project/modules/facades/mode_setting/mode_collection.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+from enum import Enum
+from pydantic import BaseModel, Field, model_validator
+
+class OrderExecutionMode(str, Enum):
+    """注文実行に関するモード"""
+    NEW = 'new'
+    NONE = 'none'
+
+class MachineLearningMode(str, Enum):
+    """機械学習に関するモード"""
+    NONE = 'none'
+    TRAIN_AND_PREDICT = 'train_and_predict'
+    PREDICT_ONLY = 'predict_only'
+    LOAD_ONLY = 'load_only'
+
+class DataUpdateMode(str, Enum):
+    """データ更新に関するモード"""
+    NONE = 'none'
+    LOAD_ONLY = 'load_only'
+    UPDATE = 'update'
+
+class ModeCollection(BaseModel):
+    """フラグ管理用のモードコレクション"""
+    order_execution_mode: OrderExecutionMode = Field(default=OrderExecutionMode.NONE)
+    machine_learning_mode: MachineLearningMode = Field(default=MachineLearningMode.NONE)
+    data_update_mode: DataUpdateMode = Field(default=DataUpdateMode.NONE)
+
+    @model_validator(mode='after')
+    def adjust_modes(cls, values: 'ModeCollection') -> 'ModeCollection':
+        messages = []
+        if (
+            values.order_execution_mode is OrderExecutionMode.NEW
+            and values.machine_learning_mode is MachineLearningMode.NONE
+        ):
+            values.machine_learning_mode = MachineLearningMode.LOAD_ONLY
+            messages.append(
+                "machine_learning_mode was 'none' but order_execution_mode is 'new'; set to 'load_only'."
+            )
+        if (
+            values.machine_learning_mode in {MachineLearningMode.TRAIN_AND_PREDICT, MachineLearningMode.PREDICT_ONLY}
+            and values.data_update_mode is DataUpdateMode.NONE
+        ):
+            values.data_update_mode = DataUpdateMode.LOAD_ONLY
+            messages.append(
+                "data_update_mode was 'none' but machine_learning_mode requires data; set to 'load_only'."
+            )
+        if messages:
+            for msg in messages:
+                print(msg)
+        return values


### PR DESCRIPTION
## Summary
- implement new `ModeCollection` under `facades.mode_setting`
- automatically adjust machine learning and data update modes when constraints are violated
- expose enums and collection in package init

## Testing
- `pytest -q` *(fails: pyenv version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b9ee3d5188332a345812b03042b3d