### PR TITLE
Add class specs generation script and docs

### DIFF
--- a/class_specs/acquisition/features_updater/facades/README.md
+++ b/class_specs/acquisition/features_updater/facades/README.md
@@ -1,0 +1,14 @@
+# acquisition/features_updater/facades のクラス仕様書
+
+## features_update_facade.py
+
+### class FeaturesUpdateFacade
+特徴量データ更新のファサードクラス（リファクタリング版）
+- __init__: Args:
+    max_concurrent_tasks (int): 同時実行タスク数の上限
+- _load_features_config: 設定ファイルから特徴量設定を読み込み
+- _display_progress: 進捗表示
+- _summarize_results: 結果の集計
+- _display_final_summary: 最終結果の表示
+- get_features_status: 全特徴量の状況を取得
+

--- a/class_specs/acquisition/features_updater/mergers/README.md
+++ b/class_specs/acquisition/features_updater/mergers/README.md
@@ -1,0 +1,11 @@
+# acquisition/features_updater/mergers のクラス仕様書
+
+## feature_data_merger.py
+
+### class FeatureDataMerger
+特徴量データの結合に特化したクラス
+- __init__: 
+- merge_feature_data: 既存の特徴量データと新しくスクレイピングしたデータを結合
+- _merge_data: 2つのデータフレームを結合
+- _format_merged_df: 結合されたデータフレームを整形
+

--- a/class_specs/acquisition/features_updater/scrapers/README.md
+++ b/class_specs/acquisition/features_updater/scrapers/README.md
@@ -1,0 +1,8 @@
+# acquisition/features_updater/scrapers のクラス仕様書
+
+## feature_scraper.py
+
+### class FeatureScraper
+ヒストリカルデータと最新値データを統合するクラス
+- __init__: 
+

--- a/class_specs/acquisition/features_updater/scrapers/feature_historical/README.md
+++ b/class_specs/acquisition/features_updater/scrapers/feature_historical/README.md
@@ -1,0 +1,9 @@
+# acquisition/features_updater/scrapers/feature_historical のクラス仕様書
+
+## feature_historical_scraper.py
+
+### class FeatureHistoricalScraper
+投資情報サイト(investing.com)からヒストリカルデータを取得するクラス
+- __init__: 
+- _format_investing_df: investing.comから取得したDataFrameを標準形式にフォーマット
+

--- a/class_specs/acquisition/features_updater/scrapers/feature_latest_value/README.md
+++ b/class_specs/acquisition/features_updater/scrapers/feature_latest_value/README.md
@@ -1,0 +1,8 @@
+# acquisition/features_updater/scrapers/feature_latest_value のクラス仕様書
+
+## feature_latest_value_scraper.py
+
+### class FeatureLatestValueScraper
+各種データソースから最新値を取得するクラス（リファクタリング後）
+- __init__: 
+

--- a/class_specs/acquisition/features_updater/scrapers/feature_latest_value/base/README.md
+++ b/class_specs/acquisition/features_updater/scrapers/feature_latest_value/base/README.md
@@ -1,0 +1,9 @@
+# acquisition/features_updater/scrapers/feature_latest_value/base のクラス仕様書
+
+## base.py
+
+### class BaseLatestValueScraper
+最新値スクレイパーの抽象基底クラス
+- __init__: 
+- _create_df_with_one_row: 単一行のDataFrameを作成（OHLC全て同じ値）
+

--- a/class_specs/acquisition/features_updater/scrapers/feature_latest_value/factory/README.md
+++ b/class_specs/acquisition/features_updater/scrapers/feature_latest_value/factory/README.md
@@ -1,0 +1,18 @@
+# acquisition/features_updater/scrapers/feature_latest_value/factory のクラス仕様書
+
+## factory.py
+
+### class ScraperFactory
+各データソースのスクレイパーを生成するファクトリークラス
+- create_scraper: 指定されたデータソースのスクレイパーを生成
+
+Args:
+    source (Literal): データソース ('Baltic', 'Tradingview', 'ARCA')
+    browser_manager (BrowserManager): ブラウザマネージャー
+    
+Returns:
+    BaseLatestValueScraper: 対応するスクレイパーインスタンス
+    
+Raises:
+    ValueError: サポートされていないデータソースが指定された場合
+

--- a/class_specs/acquisition/features_updater/scrapers/feature_latest_value/sources/README.md
+++ b/class_specs/acquisition/features_updater/scrapers/feature_latest_value/sources/README.md
@@ -1,0 +1,17 @@
+# acquisition/features_updater/scrapers/feature_latest_value/sources のクラス仕様書
+
+## arca_scraper.py
+
+### class ArcaScraper
+ARCAから最新の価格情報を取得するクラス
+
+## baltic_scraper.py
+
+### class BalticScraper
+バルチック海運取引所から最新のBDI値を取得するクラス
+
+## tradingview_scraper.py
+
+### class TradingviewScraper
+TradingViewから最新のコモディティ価格を取得するクラス
+

--- a/class_specs/acquisition/features_updater/updaters/README.md
+++ b/class_specs/acquisition/features_updater/updaters/README.md
@@ -1,0 +1,12 @@
+# acquisition/features_updater/updaters のクラス仕様書
+
+## features_updater.py
+
+### class FeatureUpdater
+特徴量データ更新の一連のフローを統合管理するクラス
+- __init__: 
+- _load_existing_data: 既存データの読み込み
+- _save_updated_data: 更新されたデータの保存
+- _get_data_file_path: データファイルのパスを取得
+- get_feature_summary: 特徴量データのサマリー情報を取得
+

--- a/class_specs/acquisition/features_updater/validators/README.md
+++ b/class_specs/acquisition/features_updater/validators/README.md
@@ -1,0 +1,16 @@
+# acquisition/features_updater/validators のクラス仕様書
+
+## data_validator.py
+
+### class FeatureDataValidator
+特徴量データの整合性検証に特化したクラス
+- __init__: 
+- validate_data_integrity: データの整合性を検証
+
+Args:
+    df (pd.DataFrame): 検証対象のデータ
+    
+Returns:
+    tuple[bool, list[str]]: (検証結果, エラーメッセージリスト)
+- validate_date_continuity: 日付の連続性を検証
+

--- a/class_specs/acquisition/jquants_api_operations/facades/README.md
+++ b/class_specs/acquisition/jquants_api_operations/facades/README.md
@@ -1,0 +1,20 @@
+# acquisition/jquants_api_operations/facades のクラス仕様書
+
+## stock_acquisition_facade.py
+
+### class StockAcquisitionFacade
+- __init__: インスタンス生成時に株式データの一括読み込みを行います。
+引数:
+    update (bool): True の場合、データを更新します。
+    process (bool): True の場合、データを加工します。
+    filter (str): 読み込み対象銘柄のフィルタリング条件（クエリ）
+    filtered_code_list (list[str]): フィルタリングする銘柄コードのをリストで指定
+- get_stock_data: targetに指定した文字列をもとに、適切なデータフレームを返します。
+Args:
+    target (Literal['list', 'fin', 'price']): どのデータフレームを取得したいか
+Returns:
+    pd.DataFrame: targetの文字列に合わせたデータフレーム
+- get_stock_data_dict: list, fin, priceを一つの辞書として返す。
+Returns:
+    dict[pd.DataFrame]
+

--- a/class_specs/acquisition/jquants_api_operations/processor/README.md
+++ b/class_specs/acquisition/jquants_api_operations/processor/README.md
@@ -1,0 +1,145 @@
+# acquisition/jquants_api_operations/processor のクラス仕様書
+
+## fin_processor.py
+
+### class FinProcessor
+財務データの前処理を行うクラス。
+
+Jquants APIで取得した財務情報データを機械学習に適した形式に変換し、整形・加工・合併処理を行う。
+加工後のデータは Parquet 形式で保存する。
+- __init__: インスタンス生成と同時にデータの加工と保存を行う。
+
+Args:
+    raw_path (str): 生の財務データの保存パス
+    processing_path (str): 加工後の財務データの保存パス
+    yaml_path (str): YAML設定ファイルのパス
+- _get_col_info: 
+- _get_column_mapping: 指定されたキーリストに基づいて、ColumnConfigsGetter からカラム名のマッピング辞書を作成する。
+
+Parameters:
+    keys (list): 取得するキーのリスト
+    column_config_getter (ColumnConfigsGetterの関数): カラム名を取得用の関数
+
+Returns:
+    dict: 指定されたキーと取得したカラム名の辞書
+- _load_fin_data: 生の財務データを読み込み、空白値を NaN に変換する。
+
+Args:
+    raw_path (str): 財務データのファイルパス
+
+Returns:
+    pd.DataFrame: 読み込んだ財務データ
+- _rename_columns: 設定ファイルをもとにカラム名を変換する。
+
+Args:
+    fin_df (pd.DataFrame): フィルタリング後の財務データ
+
+Returns:
+    pd.DataFrame: カラム名変換後の財務データ
+- _format_dtypes: 設定ファイルをもとに各カラムに適切なデータ型を設定。
+
+Args:
+    fin_df (pd.DataFrame): カラム名変換後の財務データ
+
+Returns:
+    pd.DataFrame: データ型変換後の財務データ
+- _drop_duplicated_data: 重複データを削除し、最新の発表データを保持する。
+
+Args:
+    fin_df (pd.DataFrame): データ型変換後の財務データ
+
+Returns:
+    pd.DataFrame: 重複削除後の財務データ
+- _calculate_additional_fins: 追加の財務指標を計算。
+
+Args:
+    fin_df (pd.DataFrame): 重複データ削除後の財務データ
+
+Returns:
+    pd.DataFrame: 追加計算後の財務データ
+- _merge_forecast_eps: 
+- _calculate_outstanding_shares: 期末発行済株式数の算出。
+
+Args:
+    fin_df (pd.DataFrame): 重複データ削除後の財務データ
+
+Returns:
+    pd.DataFrame: 追加計算後の財務データ
+- _append_fiscal_year_related_columns: 年度に関する追加カラムを追加します。
+
+Args:
+    fin_df (pd.DataFrame): 重複データ削除後の財務データ
+
+Returns:
+    pd.DataFrame: 追加計算後の財務データ
+- _process_merger: 企業合併時の財務情報の合成を行います。
+
+Args:
+    fin_df (pd.DataFrame): 重複データ削除後の財務データ
+
+Returns:
+    pd.DataFrame: 追加計算後の財務データ
+- _finalize_df: 最終データの整形処理を行う。
+
+Args:
+    stock_fin (pd.DataFrame): 財務データの最終処理前の状態
+
+Returns:
+    pd.DataFrame: 最終処理後のデータ
+
+## formatter.py
+
+### class Formatter
+- format_stock_code: 普通株の銘柄コードを4桁に変換するヘルパー関数
+
+## list_processor.py
+
+### class ListProcessor
+- __init__: 銘柄リストデータを加工して、機械学習用に整形します。
+
+Args:
+    raw_path (str): 生の銘柄リストデータが保存されているパス
+    processing_path (str): 加工後の銘柄リストデータを保存するパス
+- _format_dtypes: 銘柄リストのデータ型をフォーマットする。
+- _extract_individual_stocks: ETF等を除き、個別銘柄のみを抽出します。
+
+## price_processor.py
+
+### class PriceProcessor
+- __init__: 価格情報を加工して、機械学習用に整形します。
+
+Args:
+    raw_basic_path (str): 生の株価データが保存されているパス。
+    processing_basic_path (str): 加工後の株価データを保存するパス。
+- _get_col_info: 
+- _get_column_mapping: 指定されたキーリストに基づいて、ColumnConfigsGetter からカラム名のマッピング辞書を作成する。
+
+Parameters:
+    keys (list): 取得するキーのリスト
+    column_config_getter (ColumnConfigsGetterの関数): カラム名を取得用の関数
+
+Returns:
+    dict: 指定されたキーと取得したカラム名の辞書
+- _load_yearly_raw_data: 取得したままの年次株価データを読み込みます。
+- _get_dict_for_rename: 
+- _process_stock_price: 価格データを加工します。
+Args:
+    stock_price (pd.DataFrame): 加工前の株価データ
+    temp_cumprod (dict[str, float]): 
+        処理時点での銘柄ごとの暫定の累積調整係数を格納（キー: 銘柄コード、値：暫定累積調整係数）
+    is_latest_file (bool): stock_priceが最新期間のファイルかどうか
+Returns:
+    pd.DataFrame: 加工された株価データ。
+- _replace_code: ルールに従い、銘柄コードを置換します。
+- _fill_suspension_period: 銘柄コード変更前後の欠損期間のデータを埋めます。
+- _get_missing_dates: データが欠損している日付を取得します。
+- _create_missing_rows: 欠損期間の行を作成します。
+- _format_dtypes: データ型を整形します。
+- _remove_system_failure_day: システム障害によるデータ欠損日を除外します。
+- _apply_cumulative_adjustment_factor: 価格データ（OHLCV）に累積調整係数を適用します。
+- _calculate_cumulative_adjustment_factor: 累積調整係数を計算します。
+- _inherit_cumulative_values: 計算途中の暫定累積調整係数を引き継ぎます。
+- _apply_manual_adjustments: 元データで未掲載の株式分割・併合について、累積調整係数をマニュアルで調整する
+- _finalize_price_data: 最終的なデータ整形を行う。
+- _save_yearly_data: 年次の加工後価格データを保存する。
+

--- a/class_specs/acquisition/jquants_api_operations/reader/README.md
+++ b/class_specs/acquisition/jquants_api_operations/reader/README.md
@@ -1,0 +1,31 @@
+# acquisition/jquants_api_operations/reader のクラス仕様書
+
+## reader.py
+
+### class Reader
+- __init__: 抽出条件を指定します。filterとfiltered_code_listを両方設定した場合、filterの条件が優先されます。
+Args:
+    filter (str): 読み込み対象銘柄のフィルタリング条件（クエリ）
+    filtered_code_list (list[str]): フィルタリングする銘柄コードのをリストで指定
+- read_list: 銘柄一覧を読み込みます。filterとfiltered_code_listを両方設定した場合、filterの条件が優先されます。
+Args:
+    path (str): 銘柄一覧のparquetファイルのパス
+Returns:
+    pd.DataFrame: 銘柄一覧
+- read_fin: 財務情報データを読み込みます。filterとfiltered_code_listを両方設定した場合、filterの条件が優先されます。
+Args:
+    path (str): 財務情報のparquetファイルのパス
+    list_path (str): 銘柄一覧のparquetファイルのパス（フィルタリング用）
+    end_date (datetime): データの終了日
+Returns:
+    pd.DataFrame: 財務情報
+- read_price: 価格情報を読み込み、調整を行います。
+Args:
+    basic_path (str): 株価データのparquetファイルのパス
+    list_path (str): 銘柄一覧のparquetファイルのパス（フィルタリング用）
+    end_date (datetime): データの終了日
+Returns:
+    pd.DataFrame: 価格情報
+- _generate_price_df: 年次の株価データから、通期の価格データフレームを生成します。
+- _recalc_adjustment_factors: 全銘柄の最終日の累積調整係数が1となるように再計算します。
+

--- a/class_specs/acquisition/jquants_api_operations/updater/README.md
+++ b/class_specs/acquisition/jquants_api_operations/updater/README.md
@@ -1,0 +1,49 @@
+# acquisition/jquants_api_operations/updater のクラス仕様書
+
+## fin_updater.py
+
+### class FinUpdater
+- __init__: 財務情報の更新を行い、指定されたパスにParquet形式で保存する。
+:param path: Parquetファイルの保存先パス
+- _load_column_configs: 
+- _load_existing_data: 既存データを読み込む。ファイルが存在しない場合は空のDataFrameを返す。
+- _fetch_data: 財務情報をAPIから取得する。
+- _merge: 既存データと新規データを結合し、重複を排除する。
+- _format: データを指定された形式に整形する。
+
+## list_updater.py
+
+### class ListUpdater
+- __init__: 銘柄一覧の更新を行い、指定されたパスにParquet形式で保存する。
+
+:param path: Parquetファイルの保存先パス
+- _fetch: JQuants APIからデータを取得する
+- _merge: 取得したデータと既存のデータをマージする。
+
+:param fetched_stock_list_df: 取得した銘柄一覧
+:param existing_stock_list_df: 既存の銘柄一覧
+:return: マージ後の銘柄一覧
+- _format: データフレームを指定された形式に整形する。
+
+:param stock_list_df: 整形対象のデータフレーム
+:return: 整形後のデータフレーム
+
+## price_updater.py
+
+### class PriceUpdater
+- __init__: 株価情報を更新し、指定されたパスにParquet形式で保存します。
+:param basic_path: パスのテンプレート（例: "path_to_data/0000.parquet"）
+- _load_column_configs: 
+- _generate_file_path: 指定された年に基づいてファイルパスを生成します。
+- _update_yearly_stock_price: 特定の年の株価情報を取得し、更新します。
+:param year: 対象の年
+:param yearly_path: 年ごとのファイルパス
+- _update_yearly_price: 年次データを取得し、既存データを更新します。
+:param year: 対象の年
+:param existing_data: 既存の価格情報データ
+- _fetch_full_year_stock_price: 指定された年の全期間の価格情報を取得します。
+- _fetch_new_stock_price: 最新の日付までの新しい価格情報を取得します。
+- _set_adjustment_flag: AdjustmentFactorが変更された場合のフラグを設定します。
+- _update_raw_stock_price: 既存の価格情報に新しいデータを追加し、重複を削除します。
+- needs_processing: 価格データの再加工が必要かどうかを示す。
+

--- a/class_specs/acquisition/jquants_api_operations/utils/README.md
+++ b/class_specs/acquisition/jquants_api_operations/utils/README.md
@@ -1,0 +1,9 @@
+# acquisition/jquants_api_operations/utils のクラス仕様書
+
+## file_handler.py
+
+### class FileHandler
+- file_exists: 
+- read_parquet: 
+- write_parquet: 
+

--- a/class_specs/calculation/README.md
+++ b/class_specs/calculation/README.md
@@ -1,0 +1,62 @@
+# calculation のクラス仕様書
+
+## features_calculator.py
+
+### class FeaturesCalculator
+- calculate_features: 特徴量を計算する。
+:param pd.DataFrame new_sector_price: セクター価格
+:param pd.DataFrame new_sector_list: 各銘柄の業種設定
+:param dict stock_dfs_dict: J-quants API由来のデータを格納した辞書
+:param bool adopt_features_indices: インデックス系特徴量の採否
+:param bool adopt_features_price: 価格系特徴量の採否
+:param dict groups_setting: （インデックス）特徴量グループの採否
+:param dict names_setting: （インデックス）特徴量の採否
+:param str currencies_type: 通貨を'relative'なら相対強度(例：'JPY')、'raw'ならそのまま(例：'USDJPY')
+:param str commodity_type: コモディティを円建てに補正するか否か
+:param list return_duration: （価格）何日間のリターンを特徴量とするか
+:param list mom_duration: （価格）何日間のモメンタムを特徴量とするか
+:param list vola_duration: （価格）何日間のボラティリティを特徴量とするか
+:param bool adopt_size_factor: （価格）サイズファクターを特徴量とするか
+:param bool adopt_eps_factor: （価格）EPSを特徴量とするか
+:param bool adopt_sector_categorical: （価格）セクターをカテゴリ変数として採用するか
+:param bool add_rank: （価格）各日・各指標のの業種別ランキング
+:param Optional[PreprocessingPipeline] indices_preprocessing_pipeline: インデックス系特徴量の前処理パイプライン
+:param Optional[PreprocessingPipeline] price_preprocessing_pipeline: 価格系特徴量の前処理パイプライン
+- select_features_to_scrape: 
+- calculate_features_indices: 特徴量の算出
+- _calculate_1day_return: 
+- _calculate_1day_return_commodity_JPY: 
+- _process_currency: いずれ1d_return以外にも対応したい
+- _process_bond: いずれ1d_return以外にも対応したい
+- calculate_features_price: 価格系の特徴量を生成する関数。
+new_sector_price: 業種別インデックスの価格情報
+new_sector_list: 各銘柄の業種設定
+stock_dfs_dict: J-Quants API由来のデータを含んだ辞書
+return_duration: リターン算出日数をまとめたリスト
+mom_duration: モメンタム算出日数をまとめたリスト
+vola_duration: ボラティリティ算出日数をまとめたリスト
+adopt_size_factor: サイズファクターを特徴量とするか
+adopt_eps_factor: EPSを特徴量とするか
+adopt_sector_categorical: セクターをカテゴリカル変数として採用するか
+add_rank: 各日・各指標のランクを特徴量として追加するか
+- merge_features: features_indicesとfeatures_priceを結合
+
+## sector_fin_calculator.py
+
+### class SectorFinCalculator
+- __init__: 
+- _get_column_names: 
+- calculate: Args:
+    fin_df (pd.DataFrame): 財務情報
+    price_df (pd.DataFrame): 価格情報
+    sector_dif_info (pd.DataFrame): セクター
+- _weighted_average: 
+- _column_name_getter: 指定したカラム名の変換後の名称を取得。
+
+Args:
+    yaml_info (dict[str | dict[str | Any]])
+    raw_name (str): 変換前のカラム名
+
+Returns:
+    str: 変換後のカラム名
+

--- a/class_specs/calculation/facades/README.md
+++ b/class_specs/calculation/facades/README.md
@@ -1,0 +1,35 @@
+# calculation/facades のクラス仕様書
+
+## calculator_facade.py
+
+### class CalculatorFacade
+SectorIndexとFeaturesCalculatorを組み合わせて
+一連の処理を実行するファサードクラス
+- calculate_all: セクターインデックス計算と特徴量計算を一連で実行する
+
+Args:
+    stock_dfs (dict): 'list', 'fin', 'price'キーを持つ株価データ辞書
+    sector_redefinitions_csv (str): セクター定義CSVファイルのパス
+    sector_index_parquet (str): セクターインデックス出力用parquetファイルのパス
+    adopts_features_indices (bool): インデックス系特徴量の採否
+    adopts_features_price (bool): 価格系特徴量の採否
+    groups_setting (dict, optional): 特徴量グループの採否設定
+    names_setting (dict, optional): 特徴量の採否設定
+    currencies_type (str): 通貨処理方法 ('relative' or 'raw')
+    commodity_type (str): コモディティ処理方法 ('JPY' or 'raw')
+    adopt_1d_return (bool): 1日リターンを特徴量とするか
+    mom_duration (list, optional): モメンタム算出日数リスト
+    vola_duration (list, optional): ボラティリティ算出日数リスト
+    adopt_size_factor (bool): サイズファクターを特徴量とするか
+    adopt_eps_factor (bool): EPSを特徴量とするか
+    adopt_sector_categorical (bool): セクターをカテゴリ変数として採用するか
+    add_rank (bool): 各日・各指標の業種別ランキングを追加するか
+    indices_preprocessing_pipeline (PreprocessingPipeline, optional): インデックス系特徴量の前処理パイプライン
+    price_preprocessing_pipeline (PreprocessingPipeline, optional): 価格系特徴量の前処理パイプライン
+    
+Returns:
+    Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        - new_sector_price: セクターインデックス価格データ
+        - order_price_df: 発注用個別銘柄データ
+        - features_df: 特徴量データ
+

--- a/class_specs/calculation/features/base/README.md
+++ b/class_specs/calculation/features/base/README.md
@@ -1,0 +1,29 @@
+# calculation/features/base のクラス仕様書
+
+## base_features.py
+
+### class BaseFeatures
+特徴量計算の基底クラス
+- __init__: 共通の初期化処理
+- calculate_features: 特徴量を計算する抽象メソッド
+実装クラスはこのメソッド内でself.features_dfを更新する必要がある
+- apply_preprocessing: 前処理パイプラインを適用し、self.features_dfを更新
+
+Args:
+    pipeline: 前処理パイプライン
+    
+Returns:
+    前処理後の特徴量データフレーム
+- get_features: 計算済み特徴量の安全なコピーを取得
+
+Returns:
+    特徴量データフレームのコピー
+    
+Raises:
+    ValueError: 特徴量が計算されていない場合
+- has_features: 特徴量が計算済みかどうかを確認
+
+Returns:
+    特徴量が存在するかどうか
+- clear_features: 特徴量データをクリア
+

--- a/class_specs/calculation/features/facades/README.md
+++ b/class_specs/calculation/features/facades/README.md
@@ -1,0 +1,39 @@
+# calculation/features/facades のクラス仕様書
+
+## features_facade.py
+
+### class FeaturesFacade
+特徴量データフレーム作成のファサードクラス
+- __init__: 初期化
+- create_features_dataframe: 特徴量データフレームを作成
+
+Args:
+    stock_filter: 株式データフィルタ条件
+    sector_redefinitions_csv: セクター再定義CSVファイルパス
+    sector_index_parquet: セクターインデックス出力パーケットファイルパス
+    use_index_features: インデックス系特徴量を使用するか
+    use_price_features: 価格系特徴量を使用するか
+    groups_setting: インデックス特徴量グループ設定
+    names_setting: インデックス特徴量名称設定
+    currencies_type: 通貨処理タイプ
+    commodity_type: コモディティ処理タイプ
+    adopt_1d_return: 1日リターンを採用するか
+    mom_duration: モメンタム計算期間
+    vola_duration: ボラティリティ計算期間
+    adopt_size_factor: サイズファクターを採用するか
+    adopt_eps_factor: EPSファクターを採用するか
+    adopt_sector_categorical: セクターカテゴリを採用するか
+    add_rank: ランキングを追加するか
+    index_preprocessing: インデックス系前処理パイプライン
+    price_preprocessing: 価格系前処理パイプライン
+    
+Returns:
+    結合された特徴量データフレーム
+    
+Raises:
+    ValueError: 必要なパラメータが不足している場合
+- _get_stock_data: 株式データの取得
+- _prepare_sector_data: セクターデータの準備
+- _create_index_features: インデックス系特徴量の作成
+- _create_price_features: 価格系特徴量の作成
+

--- a/class_specs/calculation/features/implementation/README.md
+++ b/class_specs/calculation/features/implementation/README.md
@@ -1,0 +1,69 @@
+# calculation/features/implementation のクラス仕様書
+
+## index_features.py
+
+### class IndexFeatures
+インデックス系特徴量計算クラス
+- __init__: 初期化
+- calculate_features: インデックス系特徴量を計算し、self.features_dfを更新
+
+Args:
+    groups_setting: 特徴量グループの採否設定
+    names_setting: 特徴量の採否設定
+    currencies_type: 通貨の処理方法
+    commodity_type: コモディティの処理方法
+    preprocessing_pipeline: 前処理パイプライン (任意)
+    
+Returns:
+    計算された特徴量データフレーム
+- apply_preprocessing: 前処理パイプラインを適用し、self.features_dfを更新
+
+Args:
+    pipeline: 前処理パイプライン
+    
+Returns:
+    前処理後の特徴量データフレーム
+- _select_features_to_scrape: スクレイピング対象特徴量の選択
+- _calculate_indices_features: インデックス特徴量の計算メイン処理
+- _calculate_1day_return: 1日リターンの計算
+- _calculate_1day_return_commodity_JPY: コモディティの円建て1日リターン計算
+- _post_process_features: 通貨・債券特徴量の後処理
+- _process_currency_relative_strength: 通貨の相対強度計算
+- _process_bond_spreads: 債券スプレッドの計算
+
+## price_features.py
+
+### class PriceFeatures
+価格系特徴量計算クラス
+- __init__: 初期化
+- calculate_features: 価格系特徴量を計算し、self.features_dfを更新
+
+Args:
+    new_sector_price: セクター価格データ
+    new_sector_list: セクターリストデータ
+    stock_dfs_dict: 株価データ辞書
+    adopt_1d_return: 1日リターンを採用するか
+    mom_duration: モメンタム計算期間
+    vola_duration: ボラティリティ計算期間
+    adopt_size_factor: サイズファクターを採用するか
+    adopt_eps_factor: EPSファクターを採用するか
+    adopt_sector_categorical: セクターカテゴリを採用するか
+    add_rank: ランキングを追加するか
+    preprocessing_pipeline: 前処理パイプライン (任意)
+    
+Returns:
+    計算された特徴量データフレーム
+- apply_preprocessing: 前処理パイプラインを適用し、self.features_dfを更新
+
+Args:
+    pipeline: 前処理パイプライン
+    
+Returns:
+    前処理後の特徴量データフレーム
+- _add_return_features: リターン特徴量をself.features_dfに追加
+- _add_momentum_features: モメンタム特徴量をself.features_dfに追加
+- _add_volatility_features: ボラティリティ特徴量をself.features_dfに追加
+- _add_size_factor: サイズファクターをself.features_dfに追加
+- _add_eps_factor: EPSファクターをself.features_dfに追加
+- _add_sector_categorical: セクターカテゴリ変数をself.features_dfに追加
+

--- a/class_specs/calculation/features/integration/README.md
+++ b/class_specs/calculation/features/integration/README.md
@@ -1,0 +1,37 @@
+# calculation/features/integration のクラス仕様書
+
+## features_set.py
+
+### class FeaturesSet
+特徴量データの結合管理に特化したクラス
+- __init__: 初期化時はインスタンス生成のみ
+- combine_features: 計算済み特徴量を持つ計算器インスタンスから特徴量を結合
+
+Args:
+    index_calculator: インデックス系特徴量計算器（計算済み）
+    price_calculator: 価格系特徴量計算器（計算済み）
+    
+Returns:
+    結合された特徴量データフレーム
+- combine_from_calculators: 計算器インスタンスから特徴量を計算して結合
+
+Args:
+    index_calculator: インデックス特徴量計算器
+    price_calculator: 価格特徴量計算器
+    new_sector_price: セクター価格データ（価格系計算時に必要）
+    new_sector_list: セクターリストデータ（価格系計算時に必要）
+    stock_dfs_dict: 株価データ辞書（価格系計算時に必要）
+    index_params: インデックス系特徴量計算パラメータ
+    price_params: 価格系特徴量計算パラメータ
+    
+Returns:
+    結合された特徴量データフレーム
+- _merge_features: インデックス系と価格系特徴量の結合
+
+Args:
+    indices_features: インデックス系特徴量データフレーム
+    price_features: 価格系特徴量データフレーム
+    
+Returns:
+    結合された特徴量データフレーム
+

--- a/class_specs/calculation/sector_index/README.md
+++ b/class_specs/calculation/sector_index/README.md
@@ -1,0 +1,52 @@
+# calculation/sector_index のクラス仕様書
+
+## sector_index.py
+
+### class SectorIndex
+Stock informationからセクターインデックスを計算するメインクラス。
+- __init__: 各種データのパスとデータフレームを受け取り初期化を行う。
+
+Args:
+    stock_dfs_dict (dict): ``'price'`` および ``'fin'`` をキーにもつデータフレーム辞書。
+    sector_redefinitions_csv (str): セクター再定義 CSV へのパス。
+    sector_index_parquet (str): 計算結果を保存する parquet ファイルのパス。
+- _get_column_names: 
+- calc_sector_index: セクターインデックスを算出して ``order_price_df`` も返す。
+
+``stock_dfs_dict`` で渡された株価データと財務データを用いて
+時価総額を計算し、CSV で指定されたセクター定義を結合して
+セクターごとの指数を計算する。結果は ``sector_index_parquet``
+に保存される。
+
+Returns:
+    tuple[pd.DataFrame, pd.DataFrame]:
+        計算したセクターインデックスと発注処理用株価データ。
+- calc_sector_index_by_dict: 辞書形式のセクター定義からインデックスを計算する。
+
+Args:
+    sector_stock_dict (dict):
+        セクター名をキー、銘柄コードのリストを値とする辞書。
+        例: ``{"JPY感応株": ["6758", "6501"], "JPbond感応株": ["6751", ...]}``
+    stock_price_data (pd.DataFrame):
+        ``calc_marketcap`` の結果と同じ形式の株価データ。
+
+Returns:
+    pd.DataFrame: セクターインデックスのデータフレーム。
+- get_sector_index_dict: セクター別のデータフレーム辞書を取得する。
+
+:meth:`calc_sector_index` が未実行の場合は内部で呼び出して
+計算結果をキャッシュする。
+
+Returns
+-------
+tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame]]
+    セクターインデックスと発注処理用の価格データを、それぞれセクター別に分割した辞書を返す。
+- calc_marketcap: 各銘柄の日次時価総額を計算する。
+
+Args:
+    stock_price (pd.DataFrame): 株価データ。
+    stock_fin (pd.DataFrame): 財務データ。
+
+Returns:
+    pd.DataFrame: 時価総額および補正値を付加した株価データ。
+

--- a/class_specs/calculation/sector_index/calculators/README.md
+++ b/class_specs/calculation/sector_index/calculators/README.md
@@ -1,0 +1,29 @@
+# calculation/sector_index/calculators のクラス仕様書
+
+## index_calculator.py
+
+### class SectorIndexCalculator
+セクター別の株価データからインデックス値を算出するユーティリティ。
+- aggregate: セクターインデックスの基礎データを集約する。
+- _calculate_ohlc: 集約後のデータから OHLC を求める補助メソッド。
+
+## marketcap_calculator.py
+
+### class MarketCapCalculator
+株価データに発行済み株式数を付与し時価総額を計算する補助クラス。
+- merge_stock_price_and_shares: 株価データに発行済み株式数情報を結合する。
+- _calc_shares_at_end_period: 決算期末時点の発行済み株式数を抽出する。
+- _append_next_period_start_date: 次会計期間の開始日を営業日に丸める。
+- _find_next_business_day: 与えられた日付以降で最初の営業日を返す。
+- _merge_with_stock_price: 株価データと株式数情報をマージする。
+- calc_adjustment_factor: 株式分割などの調整係数を計算する。
+- _extract_rows_to_adjust: 分割調整が必要な行を抽出する。
+- _calc_shares_rate: 株式数変化率を計算する。
+- _correct_shares_rate_for_non_adjustment: 調整不要なケースを考慮して ``SharesRate`` を補正する。
+- _merge_shares_rate: 株数変化率を株価データにマージする。
+- _handle_special_cases: 特殊な銘柄の ``SharesRate`` を補正する。
+- _calc_cumulative_shares_rate: 変化率を累積して連続的な補正率を算出する。
+- adjust_shares: 株式数を ``CumulativeSharesRate`` で補正する。
+- calc_marketcap: OHLC 各値の時価総額を計算する。
+- calc_correction_value: 指数算出用の補正値を計算する。
+

--- a/class_specs/calculation/sector_index/preparers/README.md
+++ b/class_specs/calculation/sector_index/preparers/README.md
@@ -1,0 +1,9 @@
+# calculation/sector_index/preparers のクラス仕様書
+
+## sector_data_preparer.py
+
+### class SectorDataPreparer
+株価データにセクター定義を付与するためのユーティリティ。
+- from_csv: CSV からセクター定義を読み込み株価データに結合する。
+- from_dict: 辞書形式のセクター定義を株価データに適用する。
+

--- a/class_specs/calculation/target/README.md
+++ b/class_specs/calculation/target/README.md
@@ -1,0 +1,68 @@
+# calculation/target のクラス仕様書
+
+## pca_for_sector_target.py
+
+### class PCAforMultiSectorTarget
+機械学習用途特化PCA前処理ファサード（簡略化版）
+
+特定用途（ML目的変数前処理）に特化したシンプルなファサードパターン。
+内部でPCAHandlerを使用し、ML特化の前後処理を提供。
+時系列対応により大幅に簡略化。
+
+Parameters
+----------
+n_components : int
+    抽出する主成分の数
+fit_start : datetime, str, or None, optional
+    学習期間の開始日。Noneの場合は全期間を使用
+fit_end : datetime, str, or None, optional
+    学習期間の終了日。Noneの場合は全期間を使用
+target_column : str, default='Target'
+    対象となる列名
+mode : str, default='residuals'
+    'residuals': 残差を抽出
+    'components': 主成分を抽出
+    'transform': PCA変換結果を直接取得
+copy : bool, default=True
+    データをコピーするかどうか
+random_state : int, optional
+    乱数シード
+- __init__: 
+- apply_pca: ML用途特化のPCA前処理を実行
+
+初回実行時は学習も同時に行い、2回目以降は学習済みパラメータで変換のみ実行。
+BasePreprocessorの時系列機能により大幅に簡略化。
+
+Parameters
+----------
+X : pd.DataFrame
+    処理対象データ（二階層インデックス必須）
+    
+Returns
+-------
+X_transformed : pd.DataFrame
+    PCA処理後のデータ
+- _prepare_data: 学習・変換用データフレームを準備（ML特化処理）
+- _restore_dataframe_format: 変換後の配列をDataFrame形式に復元
+- get_explained_variance_ratio: 各主成分の寄与率を取得
+- get_cumulative_explained_variance_ratio: 累積寄与率を取得
+- get_components: 主成分ベクトルをDataFrame形式で取得
+- get_feature_names_out: 変換後の特徴量名を取得
+- get_fit_info: fit状態と設定情報を取得（PCAHandlerの情報も含む）
+- is_fitted: fit状態を確認
+- fit_start: fit開始日を取得
+- fit_end: fit終了日を取得
+- underlying_pca: 内部のPCAHandlerインスタンスにアクセス（上級者向け）
+
+## target_calculator.py
+
+### class TargetCalculator
+- daytime_return: 日中生リターンを算出する。
+Args:
+    df (pd.DataFrame): 元データ（Open, Closeの各列が必須）
+Returns:
+    pd.DataFrame: 日中リターン（Target列）を含むDataFrame
+- daytime_return_PCAresiduals: PCAで主成分を除去した日中リターンの残差を算出。
+Returns:
+    tuple[pd.DataFrame, pd.DataFrame]: 生の日中リターン, PCA残差リターン
+

--- a/class_specs/clustering/README.md
+++ b/class_specs/clustering/README.md
@@ -1,0 +1,40 @@
+# clustering のクラス仕様書
+
+## hdbscan_cluster.py
+
+### class HDBSCANCluster
+HDBSCAN を用いたクラスタリング処理を担うクラス
+- fit: 複数パラメータでクラスタリングを実行し、シルエット係数で最良の結果を返す
+- fit_recursive: 再帰的にクラスタリングを実行し、各段階のラベルを保持する
+
+## pca_residuals.py
+
+### class PCAResidualExtractor
+指定した主成分数を除去した残差を返す簡易クラス
+- __init__: 
+- fit: 
+- transform: 
+- fit_transform: 
+
+## pipeline.py
+
+### class SectorClusteringPipeline
+UMAP -> HDBSCAN -> 距離解析 をまとめたパイプライン
+- __init__: 
+- execute: パイプライン全体を実行し、最終的なクラスタ付与結果を返す
+
+## reducer.py
+
+### class UMAPReducer
+UMAP を用いた次元削減処理を行うクラス
+- fit_transform: UMAP により次元削減を行い、結果の DataFrame を返す
+
+## sector_clusterer.py
+
+### class SectorClusterer
+セクタークラスタリングを補助する互換用クラス
+- __init__: 
+- apply_umap: 
+- apply_hdbscan: 
+- apply_recursive_hdbscan: HDBSCAN を再帰的に適用しクラスタを細分化する
+

--- a/class_specs/evaluation/README.md
+++ b/class_specs/evaluation/README.md
@@ -1,0 +1,20 @@
+# evaluation のクラス仕様書
+
+## trade_history_analyzer.py
+
+### class TradeHistoryAnalyzer
+- __init__: 
+- calculate_daily_profit: 日次の利益を算出する。
+- calculate_daily_profit_by_sector: 日次の業種別利益を算出する。
+- calculate_daily_leveraged: 
+- calculate_daily_cumulative: 
+- calculate_daily_leveraged_cumurative: 
+- calculate_monthly_profit: 
+- calculate_monthly_profit_by_sector: 
+- calculate_monthly_leveraged: 
+- calculate_total_profit: 
+- calculate_total_profit_by_sector: 
+- calculate_total_leveraged: 
+- display_result: 任意のデータフレームを動的に描画(改善版)
+- plot_graphs: 任意のグラフを動的に描画
+

--- a/class_specs/facades/README.md
+++ b/class_specs/facades/README.md
@@ -1,0 +1,17 @@
+# facades のクラス仕様書
+
+## evaluation_facade.py
+
+### class EvaluationFacade
+- __init__: 
+- display: 
+
+## sector_ml_datasets_facade.py
+
+### class SectorMLDatasetsFacade
+業種単位での学習用データセット作成をまとめて実行するファサード。
+- create_datasets: 業種ごとの ``SingleMLDataset`` を生成し ``MLDatasets`` として保存する。
+
+各種パラメータは ``FeaturesSet`` や ``TargetCalculator`` へ渡され、
+特徴量計算からデータセットの保存までを一括で行う。
+

--- a/class_specs/facades/data_pipeline/README.md
+++ b/class_specs/facades/data_pipeline/README.md
@@ -1,0 +1,36 @@
+# facades/data_pipeline のクラス仕様書
+
+## data_update_facade.py
+
+### class DataUpdateFacade
+データの更新及び読み込みを担当するファサード
+- __init__: 
+
+## machine_learning_facade.py
+
+### class MachineLearningFacade
+- __init__: 
+- execute: 
+- _get_necessary_dfs: 
+- _load_model: 
+- _train_1st_model: 
+- _predict_1st_model: 
+- _train_2nd_model: 
+- _predict_2nd_model: 
+- _ensemble: 
+- _update_ensembled_model: 
+- _get_features_df: 
+- _append_pred_in_1st_model: 
+
+## order_execution_facade.py
+
+### class OrderExecutionFacade
+SBI証券でオーダーする
+- __init__: 
+
+## trade_data_facade.py
+
+### class TradeDataFacade
+取引データを取得するコード
+- __init__: 
+

--- a/class_specs/facades/mode_setting/README.md
+++ b/class_specs/facades/mode_setting/README.md
@@ -1,0 +1,33 @@
+# facades/mode_setting のクラス仕様書
+
+## mode_collection.py
+
+### class DataUpdateMode
+データ更新に関するモード
+
+### class MachineLearningMode
+機械学習に関するモード
+
+### class OrderExecutionMode
+注文実行に関するモード
+
+### class TradeDataFetchMode
+データ更新に関するモード
+
+### class ModeCollection
+フラグ管理用クラス
+- adjust_modes: 
+- model_copy: モデルをコピーし、更新後にバリデーションを実行する。
+
+## mode_factory.py
+
+### class ModeFactory
+- create_mode_collection: 
+
+## mode_for_strategy.py
+
+### class ModeForStrategy
+- generate_mode: 現在時刻に基づいたModeCollectionを返す。
+- _select_mode: 現在時刻に基づいてモードを決定する。
+- _is_between: 現在時刻が指定した時間範囲内にあるかを判定
+

--- a/class_specs/models/evaluation/README.md
+++ b/class_specs/models/evaluation/README.md
@@ -1,0 +1,55 @@
+# models/evaluation のクラス仕様書
+
+## evaluate.py
+
+### class DatetimeManager
+- __init__: 対象日を管理するサブモジュール
+Args:
+    start_date (datetime): 評価開始日
+    end_date (datetim): 評価終了日
+- extract_duration: 指定した日付のデータを抽出する。
+
+### class LSControlHandler
+コントロールデータを読み込む。
+type (Literal[str]): コントロールの種類を指定。デフォルトはTOPIX。
+- __init__: 
+- _load_topix_data: TOPIXデータをpandas.DataFrame形式で読み込む。
+- _get_topix_path: TOPIXデータのファイルパスを取得する。
+- _calculate_return: リターンを計算する。
+
+### class LSDataHandler
+コントロールデータを読み込む
+type (Literal[str]): コントロールの種類を指定。デフォルトはTOPIX。
+- __init__: 
+- _append_rank_cols: データフレームの各列をランク化します。
+- _append_raw_target_col: 
+
+### class MetricsCalculator
+指標計算を担当
+- __init__: Long-Short戦略のモデルの予測結果を格納し、各種指標を計算します。
+Args:
+    ls_data_handler (LSDataHandler): ロングショート戦略の各種データを保持するクラス
+    sectors_to_trade_count (int): 上位（下位）何sectorを取引の対象とするか。
+    quantile_bin_count (int):分位リターンのbin数。指定しない場合はsector数が割り当てられる。
+    top_sector_weight (float): 最上位（最下位）予想業種にどれだけの比率で傾斜を掛けるか？
+- _calculate_all_metrics: 
+- calculate_return_by_quantile_bin: 指定したbin数ごとのリターンを算出。
+- calculate_longshort_performance: ロング・ショートそれぞれの結果を算出する。
+- calculate_longshort_probability: Long, Short, LSの各リターンを算出する。
+- calculate_longshort_minus_control: コントロールを差し引いたリターン結果を表示する。
+- calculate_monthly_longshort: 月次のリターンを算出
+- calculate_daily_sector_performances: 業種ごとの成績を算出する
+- calculate_monthly_sector_performances: 業種ごとの月次リターンの算出
+- calculate_total_sector_performances: 
+- calculate_spearman_correlation: 日次のSpearman順位相関係数と、その平均や標準偏差を算出
+- calculate_numerai_correlationss: 日次のnumerai_corrと，その平均や標準偏差を算出
+numerai_corr：上位・下位の予測に重みづけされた，より実践的な指標．
+- _calc_daily_numerai_corr: 日次のnumerai_corrを算出
+- _calc_daily_numerai_rank_corr: 日次のnumerai_corr（Targetをランク化）を算出
+
+### class Visualizer
+計算結果の可視化を担当
+- __init__: 
+- _output_basic_data: 
+- display_result: 任意のデータフレームを動的に描画
+

--- a/class_specs/models/machine_learning/ensembles/README.md
+++ b/class_specs/models/machine_learning/ensembles/README.md
@@ -1,0 +1,80 @@
+# models/machine_learning/ensembles のクラス仕様書
+
+## base_ensemble_method.py
+
+### class BaseEnsembleMethod
+アンサンブル手法の抽象基底クラス
+- ensemble: アンサンブルを実行する抽象メソッド
+
+Args:
+    inputs (List[Tuple[pd.DataFrame, float]]): (予測結果データフレーム, 重み)のタプルのリスト
+    
+Returns:
+    pd.DataFrame: アンサンブル後の予測結果を格納したデータフレーム
+- _validate_inputs: 入力の妥当性をチェック
+- _normalize_weights: 重みを正規化（合計を1.0にする）
+
+## by_predict_value.py
+
+### class ByPredictValueMethod
+予測値ベースでのアンサンブル手法
+- ensemble: 予測値の重み付き平均でアンサンブルを実行
+
+Args:
+    inputs (List[Tuple[pd.DataFrame, float]]): (予測結果データフレーム, 重み)のタプルのリスト
+    
+Returns:
+    pd.DataFrame: アンサンブル後の予測値を格納したデータフレーム
+
+## by_rank.py
+
+### class ByRankMethod
+予測順位ベースでのアンサンブル手法
+- ensemble: 予測順位ベースでアンサンブルを実行
+
+Args:
+    inputs (List[Tuple[pd.DataFrame, float]]): (予測結果データフレーム, 重み)のタプルのリスト
+    
+Returns:
+    pd.DataFrame: アンサンブル後の予測順位を格納したデータフレーム
+
+## by_voting.py
+
+### class ByVotingMethod
+投票ベースでのアンサンブル手法
+- __init__: Args:
+    top_n (int): 各モデルの上位何位までを考慮するか
+- ensemble: 各モデルの上位予測に投票を行いアンサンブルを実行
+
+Args:
+    inputs (List[Tuple[pd.DataFrame, float]]): (予測結果データフレーム, 重み)のタプルのリスト
+    
+Returns:
+    pd.DataFrame: アンサンブル後の投票スコアを格納したデータフレーム
+
+## factory.py
+
+### class EnsembleMethodFactory
+アンサンブル手法のインスタンスを生成・管理するためのファクトリークラス。
+
+事前に登録されたアンサンブル手法を名前で取得したり、
+新たな手法を登録するための機能を提供する。
+
+デフォルトで利用可能なアンサンブル手法は以下の通り:
+    - 'by_rank': 予測値のランクに基づく手法
+    - 'by_predict_value': 予測値の大小に基づく手法
+    - 'by_voting': クラスごとの投票に基づく手法
+- create_method: 指定された名前のアンサンブル手法を作成
+
+Args:
+    method_name (str): アンサンブル手法の名前
+    **kwargs: アンサンブル手法固有のパラメータ
+    
+Returns:
+    BaseEnsembleMethod: アンサンブル手法のインスタンス
+    
+Raises:
+    ValueError: 存在しない手法名が指定された場合
+- get_available_methods: 利用可能なアンサンブル手法の一覧を取得
+- register_method: 新しいアンサンブル手法を登録
+

--- a/class_specs/models/machine_learning/loaders/README.md
+++ b/class_specs/models/machine_learning/loaders/README.md
@@ -1,0 +1,10 @@
+# models/machine_learning/loaders のクラス仕様書
+
+## loader.py
+
+### class DatasetLoader
+``MLDatasets`` の作成・読み込みをまとめたユーティリティクラス.
+- __init__: 
+- create_grouped_datasets: グループ単位で ``SingleMLDataset`` を作成し ``MLDatasets`` として保存する。
+- load_datasets: 保存済み ``SingleMLDataset`` 群から ``MLDatasets`` を復元する.
+

--- a/class_specs/models/machine_learning/ml_dataset/README.md
+++ b/class_specs/models/machine_learning/ml_dataset/README.md
@@ -1,0 +1,48 @@
+# models/machine_learning/ml_dataset のクラス仕様書
+
+## ml_datasets.py
+
+### class MLDatasets
+複数のSingleMLDatasetを統合管理するクラス
+- __init__: 
+- append_model: SingleMLDatasetを追加
+- remove_model: 指定された名前のモデルを削除
+- replace_model: 既存のモデルを差し替え（同じ名前のモデルが存在する場合）
+- get_model: 指定された名前のモデルを取得
+- get_model_names: 登録されているモデル名の一覧を取得
+- _merge_dfs: 各モデルからDataFrameを取得して結合するヘルパー
+- get_pred_result: 各SingleMLDatasetの予測結果dfをconcatして日付順に並べたものを出力
+
+Args:
+    model_names (Optional[List[str]]): 対象とするモデル名のリスト。
+                                      Noneの場合は全モデルを対象とする。
+
+Returns:
+    pd.DataFrame: 統合された予測結果データフレーム
+- get_raw_target: raw_target_dfをマージして返却
+- get_order_price: order_price_dfをマージして返却
+- save_all: 全てのモデルを保存
+- __len__: 登録されているモデル数を返す
+- __contains__: 指定されたモデル名が登録されているかチェック
+- __iter__: イテレータ（モデル名でイテレート）
+- items: (モデル名, SingleMLDataset)のペアを返す
+
+## single_ml_dataset.py
+
+### class SingleMLDataset
+単体機械学習データセットの統合管理
+- __init__: 
+- get_name: オブジェクトの名称を取得
+- save: 全体を保存
+- archive_train_test_data: TrainTestData の archive メソッドを実行
+- archive_ml_objects: MLObjects の archive メソッドを実行
+- archive_post_processing_data: PostProcessingData の archive メソッドを実行
+- archive_raw_target: raw_target_dfをアーカイブ
+- archive_order_price: order_price_dfをアーカイブ
+- archive_pred_result: pred_result_dfをアーカイブ
+- train_test_materials: 
+- ml_object_materials: 
+- evaluation_materials: 
+- stock_selection_materials: 
+- copy_from_other_dataset: 他のデータセットからすべてのインスタンス変数をコピー
+

--- a/class_specs/models/machine_learning/ml_dataset/components/README.md
+++ b/class_specs/models/machine_learning/ml_dataset/components/README.md
@@ -1,0 +1,52 @@
+# models/machine_learning/ml_dataset/components のクラス仕様書
+
+## base_data_component.py
+
+### class BaseDataComponent
+データコンポーネントの抽象基底クラス
+- __init__: 
+- _load_all_data: 全データをロード
+- _load_file: 単一ファイルをロード
+- save_instance: インスタンスを保存
+- _save_file: 単一ファイルを保存
+- getter: データクラスとして返却（サブクラスで実装）
+
+## ml_objects.py
+
+### class MLObjects
+機械学習オブジェクトの管理
+- archive_ml_objects: 機械学習のモデルとスケーラーを格納
+- getter: データクラスとして返却
+
+``_model`` や ``_scaler`` が存在しない場合は ``None`` を返す。
+予測のみを行う際に ``archive_ml_objects`` が呼ばれていない状況でも
+エラーとならないようにしている。
+
+## post_processing_data.py
+
+### class PostProcessingData
+後処理データの管理
+- archive_raw_target: 生の目的変数を格納
+- archive_order_price: 個別銘柄の発注価格を格納
+- archive_pred_result: 予測結果を格納
+- getter_stock_selection: 株式選択用データを返却
+- getter_evaluation: 評価用データを返却
+- getter: デフォルトのgetter（評価用データを返却）
+
+## train_test_data.py
+
+### class TrainTestData
+訓練・テストデータの管理と前処理を担当
+- archive: データの前処理と分割を実行
+- _prepare_target_data: 目的変数データの前処理
+- _prepare_features_data: 特徴量データの前処理
+- _split_data: データを学習・テストに分割
+- _remove_outliers: 外れ値除去
+- _append_next_business_day_row: 次の営業日の行を追加
+- _shift_features: 特徴量を1日シフト
+- _align_index: 特徴量のインデックスを目的変数と揃える
+- _narrow_period: 指定期間でデータを絞り込み
+- _filter_outliers_from_datasets: 外れ値除去の実行
+- _filter_outliers_by_group: グループ単位での外れ値除去
+- getter: データクラスとして返却
+

--- a/class_specs/models/machine_learning/models/README.md
+++ b/class_specs/models/machine_learning/models/README.md
@@ -1,0 +1,77 @@
+# models/machine_learning/models のクラス仕様書
+
+## base_model.py
+
+### class BaseModel
+機械学習モデルの抽象基底クラス
+- train: 学習を実行する抽象メソッド
+
+Args:
+    target_train_df (pd.DataFrame): 訓練用の目的変数データフレーム
+    features_train_df (pd.DataFrame): 訓練用の特徴量データフレーム
+    **kwargs: モデル固有のハイパーパラメータ
+    
+Returns:
+    TrainerOutputs: 学習済みモデルとスケーラーを格納したデータクラス
+- predict: 予測を実行する抽象メソッド
+
+Args:
+    target_test_df (pd.DataFrame): テスト用の目的変数データフレーム
+    features_test_df (pd.DataFrame): テスト用の特徴量データフレーム
+    model (Any): 学習済みモデル
+    scaler (Optional[Any]): スケーラー（必要な場合）
+    
+Returns:
+    pd.DataFrame: 予測結果のデータフレーム
+
+## lasso_model.py
+
+### class LassoModel
+LASSOモデルのファサードクラス
+- train: LASSOによる学習を管理します。
+
+Args:
+    target_train_df (pd.DataFrame): 訓練用の目的変数データフレーム
+    features_train_df (pd.DataFrame): 訓練用の特徴量データフレーム
+    max_features (int): 採用する特徴量の最大値
+    min_features (int): 採用する特徴量の最小値
+    **kwargs: LASSOのハイパーパラメータを任意で設定可能
+    
+Returns:
+    TrainerOutputs: モデルとスケーラーを格納したデータクラス
+- predict: LASSOによる予測を管理します。
+
+Args:
+    target_test_df (pd.DataFrame): テスト用の目的変数データフレーム
+    features_test_df (pd.DataFrame): テスト用の特徴量データフレーム
+    model (Lasso): LASSOモデル
+    scaler (StandardScaler): LASSOモデルに対応したスケーラー
+    
+Returns:
+    pd.DataFrame: 予測結果のデータフレーム
+
+## lgbm_model.py
+
+### class LgbmModel
+LightGBMモデルのファサードクラス
+- train: lightGBMによる学習を管理します。
+
+Args:
+    target_train_df (pd.DataFrame): 訓練用の目的変数データフレーム
+    features_train_df (pd.DataFrame): 訓練用の特徴量データフレーム
+    categorical_features (Optional[List[str]]): カテゴリ変数として使用する特徴量
+    **kwargs: lightGBMのハイパーパラメータを任意で設定可能
+    
+Returns:
+    TrainerOutputs: モデルとスケーラーを格納したデータクラス
+- predict: lightGBMによる予測を管理します。
+
+Args:
+    target_test_df (pd.DataFrame): テスト用の目的変数データフレーム
+    features_test_df (pd.DataFrame): テスト用の特徴量データフレーム
+    model (lgb.train): LightGBMモデル
+    scaler (Optional[object]): 使用しない（LightGBMでは不要）
+    
+Returns:
+    pd.DataFrame: 予測結果のデータフレーム
+

--- a/class_specs/models/machine_learning/outputs/README.md
+++ b/class_specs/models/machine_learning/outputs/README.md
@@ -1,0 +1,18 @@
+# models/machine_learning/outputs のクラス仕様書
+
+## evaluation_materials.py
+
+### class EvaluationMaterials
+
+## stock_selection_materials.py
+
+### class StockSelectionMaterials
+
+## train_test_datasets.py
+
+### class TrainTestDatasets
+
+## trainer_outputs.py
+
+### class TrainerOutputs
+

--- a/class_specs/models/machine_learning/predictors/README.md
+++ b/class_specs/models/machine_learning/predictors/README.md
@@ -1,0 +1,53 @@
+# models/machine_learning/predictors のクラス仕様書
+
+## base_predictor.py
+
+### class BasePredictor
+機械学習モデルの予測器の抽象基底クラス
+- __init__: Args:
+    target_test_df (pd.DataFrame): テスト用の目的変数データフレーム
+    features_test_df (pd.DataFrame): テスト用の特徴量データフレーム
+    models (List[Any]): 学習済みモデルのリスト
+    scalers (Optional[List[Any]]): スケーラーのリスト（必要な場合）
+- _validate_inputs: 入力の妥当性をチェック
+- predict: 予測を行う抽象メソッド
+
+Returns:
+    pd.DataFrame: 予測結果を格納したデータフレーム
+- _is_multi_sector: マルチセクターかどうかを判定
+- _get_sectors: セクター一覧を取得
+
+## lasso_predictor.py
+
+### class LassoPredictor
+LASSOモデルの予測器クラス
+- __init__: LASSOによる予測を管理します。
+
+Args:
+    target_test_df (pd.DataFrame): テスト用の目的変数データフレーム
+    features_test_df (pd.DataFrame): テスト用の特徴量データフレーム
+    models (List[Lasso]): LASSOモデルを格納したリスト
+    scalers (List[StandardScaler]): LASSOモデルに対応したスケーラーを格納したリスト
+- predict: LASSOによる予測を行います。シングルセクターとマルチセクターの双方に対応しています。
+
+Returns:
+    pd.DataFrame: 予測結果を格納したデータフレーム
+- _pred_single_sector: LASSOモデルで予測して予測結果を返す関数
+- _pred_multi_sectors: 複数セクターに関して、LASSOモデルで予測して予測結果を返す関数
+
+## lgbm_predictor.py
+
+### class LgbmPredictor
+LightGBMモデルの予測器クラス
+- __init__: lightGBMによる予測を管理します。
+
+Args:
+    target_test_df (pd.DataFrame): テスト用の目的変数データフレーム
+    features_test_df (pd.DataFrame): テスト用の特徴量データフレーム
+    models (List[lgb.train]): lightGBMモデルを格納したリスト
+    categorical_features (Optional[List[str]]): カテゴリ変数の一覧
+- predict: lightGBMによる予測を行います。シングルセクターとマルチセクターの双方に対応しています。
+
+Returns:
+    pd.DataFrame: 予測結果を格納したデータフレーム
+

--- a/class_specs/models/machine_learning/trainers/README.md
+++ b/class_specs/models/machine_learning/trainers/README.md
@@ -1,0 +1,51 @@
+# models/machine_learning/trainers のクラス仕様書
+
+## base_trainer.py
+
+### class BaseTrainer
+機械学習モデルのトレーナーの抽象基底クラス
+- __init__: Args:
+    target_train_df (pd.DataFrame): 訓練用の目的変数データフレーム
+    features_train_df (pd.DataFrame): 訓練用の特徴量データフレーム
+- train: モデルの学習を行う抽象メソッド
+
+Args:
+    **kwargs: モデル固有のハイパーパラメータ
+    
+Returns:
+    TrainerOutputs: 学習済みモデルとスケーラーを格納したデータクラス
+- _is_multi_sector: マルチセクターかどうかを判定
+- _get_sectors: セクター一覧を取得
+
+## lasso_trainer.py
+
+### class LassoTrainer
+LASSOモデルのトレーナークラス
+- train: LASSOによる学習を行います。シングルセクターとマルチセクターの双方に対応しています。
+
+Args:
+    max_features (int): 採用する特徴量の最大値
+    min_features (int): 採用する特徴量の最小値
+    **kwargs: LASSOのハイパーパラメータを任意で設定可能
+    
+Returns:
+    TrainerOutputs: モデルとスケーラーを設定したデータクラス
+- _train_single_sector: LASSOで学習して，モデルとスケーラーを返す関数
+- _search_alpha: 適切なalphaの値をサーチする。
+残る特徴量の数が、min_features以上、max_feartures以下となるように
+- _get_feature_importances_df: feature importancesをdf化して返す
+
+## lgbm_trainer.py
+
+### class LgbmTrainer
+LightGBMモデルのトレーナークラス
+- train: lightGBMによる学習を行います。シングルセクターとマルチセクターの双方に対応しています。
+
+Args:
+    categorical_features (Optional[List[str]]): カテゴリ変数の一覧
+    **kwargs: lightgbmのハイパーパラメータを任意で設定可能
+    
+Returns:
+    TrainerOutputs: モデルを設定したデータクラス
+- _numerai_corr_lgbm: LightGBM用のカスタム評価関数（numerai correlation）
+

--- a/class_specs/preprocessing/methods/README.md
+++ b/class_specs/preprocessing/methods/README.md
@@ -1,0 +1,186 @@
+# preprocessing/methods のクラス仕様書
+
+## base_preprocessor.py
+
+### class BasePreprocessor
+前処理クラスの抽象基底クラス
+
+全ての前処理クラスが継承すべき共通インターフェースを定義。
+scikit-learn互換のTransformerとして動作。
+時系列データに対応し、指定期間でfitして全期間でtransformすることが可能。
+
+Parameters
+----------
+copy : bool, default=True
+    データをコピーするかどうか
+fit_start : str, pd.Timestamp, or None, default=None
+    fitに使用する開始日時。Noneの場合は全期間を使用
+fit_end : str, pd.Timestamp, or None, default=None
+    fitに使用する終了日時。Noneの場合は全期間を使用
+time_column : str or None, default='Date'
+    時間列の名前。Noneの場合はindexを時間として使用
+- __init__: 
+- _filter_data_by_time: 指定された期間でデータをフィルタリング
+
+Parameters
+----------
+X : pd.DataFrame or np.ndarray
+    入力データ
+start : str, pd.Timestamp, or None
+    開始日時
+end : str, pd.Timestamp, or None
+    終了日時
+    
+Returns
+-------
+Union[pd.DataFrame, np.ndarray]
+    フィルタリングされたデータ
+- fit: 前処理のパラメータを学習
+- transform: 学習したパラメータを使って変換を実行
+- fit_transform: fit と transform を同時に実行
+- _validate_input: 入力データの妥当性をチェック
+- _mark_as_fitted: fit完了をマークし、重要な属性を記録
+
+このメソッドを継承クラスのfit()の最後で呼び出すだけで
+バリデーションが機能するようになる
+
+Parameters
+----------
+**kwargs : 任意のキーワード引数
+    fit時に設定された重要な属性を渡す
+    例: self._mark_as_fitted(pca_=self.pca_, n_components_=self.n_components)
+- _check_is_fitted: fitが実行済みかチェック（簡素化版）
+
+Parameters
+----------
+additional_attributes : List[str], optional
+    追加でチェックしたい属性があれば指定
+- _store_fit_metadata: fit時に共通メタデータを保存するヘルパーメソッド
+- get_feature_names_out: 変換後の特徴量名を取得（sklearn互換）
+- _prepare_output: 出力データの準備（コピーの処理など）
+- _get_feature_names_from_input: 入力データから特徴量名を取得
+- get_fit_info: fit状態と設定された属性の情報を取得
+
+## feature_neutralizer.py
+
+### class FeatureNeutralizer
+特徴量の直交化を行うTransformer
+
+BasePreprocessorを継承し、統一されたインターフェースを提供。
+指定期間でfitし、全期間でtransformすることが可能。
+
+Parameters
+----------
+target_features : str, list of str, or None
+    直交化対象の列名。Noneの場合は全列を互いに直交化
+neutralize_features : str, list of str, or None
+    直交化に使用する列名。target_featuresがNoneでない場合に必須
+mode : str, default='mutual'
+    'mutual': 全列を互いに直交化
+    'specific': 指定列を指定列で直交化
+copy : bool, default=True
+    データをコピーするかどうか
+fit_intercept : bool, default=False
+    線形回帰で切片を含めるかどうか
+fit_start : str, pd.Timestamp, or None, default=None
+    fitに使用する開始日時
+fit_end : str, pd.Timestamp, or None, default=None
+    fitに使用する終了日時
+time_column : str or None, default='Date'
+    時間列の名前
+- __init__: 
+- _validate_params: パラメータの妥当性をチェック
+- fit: 直交化のパラメータを学習（指定期間のデータを使用）
+- _fit_regression_coefficients: 特定の直交化のための回帰係数を学習
+- _fit_mutual_neutralization: 相互直交化のためのパラメータを学習
+- transform: 直交化を実行（全期間のデータに適用）
+- _apply_specific_neutralization: 特定の直交化を適用
+- _apply_mutual_neutralization: 相互直交化を適用（簡単な実装例）
+- _ensure_list: ヘルパーメソッド
+
+## pca_handler.py
+
+### class PCAHandler
+汎用PCA処理クラス
+
+numpy配列またはDataFrameの数値データに対してPCAを適用し、
+主成分の抽出、残差の取得、またはPCA変換結果の取得を行う。
+指定期間でfitし、全期間でtransformすることが可能。
+
+Parameters
+----------
+n_components : int
+    抽出する主成分の数
+mode : str, default='components'
+    'components': 主成分を抽出（逆変換して元空間に戻す）
+    'residuals': 残差を抽出
+    'transform': PCA変換結果を直接取得
+copy : bool, default=True
+    データをコピーするかどうか
+random_state : int, optional
+    乱数シード
+fit_start : str, pd.Timestamp, or None, default=None
+    fitに使用する開始日時
+fit_end : str, pd.Timestamp, or None, default=None
+    fitに使用する終了日時
+time_column : str or None, default='Date'
+    時間列の名前
+- __init__: 
+- _validate_params: パラメータの妥当性をチェック
+- fit: PCAのパラメータを学習（指定期間のデータを使用）
+- transform: PCA変換を実行（全期間のデータに適用）
+- _to_numeric_array: ヘルパーメソッド - 数値データを配列に変換
+- _handle_missing_values: 欠損値を処理（fit時の統計で補完）
+- _extract_components: ヘルパーメソッド - 主成分を抽出
+- _extract_residuals: ヘルパーメソッド - 残差を抽出
+- get_explained_variance_ratio: 寄与率を取得
+- get_cumulative_explained_variance_ratio: 累積寄与率を取得
+- get_components: 主成分ベクトルを取得
+
+## standardizer.py
+
+### class Standardizer
+指定期間でfitする標準化Transformer
+
+BasePreprocessorを継承し、統一されたインターフェースを提供。
+指定期間でStandardScalerをfitし、全期間でtransformすることが可能。
+
+Parameters
+----------
+with_mean : bool, default=True
+    平均を0にするかどうか（標準化）
+with_std : bool, default=True
+    標準偏差を1にするかどうか（標準化）
+target_columns : list of str or None, default=None
+    標準化対象の列名。Noneの場合は全ての数値列を対象
+copy : bool, default=True
+    データをコピーするかどうか
+fit_start : str, pd.Timestamp, or None, default=None
+    fitに使用する開始日時
+fit_end : str, pd.Timestamp, or None, default=None
+    fitに使用する終了日時
+time_column : str or None, default='Date'
+    時間列の名前
+    
+Attributes
+----------
+scaler_ : StandardScaler
+    fit済みのStandardScaler
+target_columns_ : list of str
+    実際に標準化対象となった列名
+mean_ : array-like
+    fit期間の平均値
+scale_ : array-like
+    fit期間のスケール（標準偏差）
+var_ : array-like
+    fit期間の分散
+- __init__: 
+- fit: 標準化のパラメータを学習（指定期間のデータを使用）
+- transform: 標準化を実行（全期間のデータに適用）
+- inverse_transform: 標準化を逆変換（標準化前の値に戻す）
+- _get_target_columns: 標準化対象の列を決定
+- _extract_target_data: 標準化対象のデータを配列として抽出
+- _restore_data_format: 変換結果を元の形式に復元
+- get_feature_names_out: 変換後の特徴量名を取得（sklearn互換）
+- get_statistics: fit期間の統計量を取得
+

--- a/class_specs/preprocessing/methods/template/README.md
+++ b/class_specs/preprocessing/methods/template/README.md
@@ -1,0 +1,26 @@
+# preprocessing/methods/template のクラス仕様書
+
+## template.py
+
+### class YourPreprocessorName
+[概要]
+この前処理クラスは ○○ を行います。
+
+Parameters
+----------
+param1 : type
+    パラメータの説明
+...
+- __init__: 
+- fit: fit処理：指定期間のデータでパラメータを学習
+[必須呼び出し]
+    - self._validate_input(X)
+    - self._filter_data_by_time(X, self.fit_start, self.fit_end)
+    - self._store_fit_metadata(X)
+    - self._mark_as_fitted(...)  # 必ず最後に
+- transform: transform処理：全期間データに対して前処理を適用
+[必須呼び出し]
+    - self._check_is_fitted()
+    - self._validate_input(X)
+    - self._prepare_output(X)
+

--- a/class_specs/preprocessing/pipeline/README.md
+++ b/class_specs/preprocessing/pipeline/README.md
@@ -1,0 +1,19 @@
+# preprocessing/pipeline のクラス仕様書
+
+## pipeline.py
+
+### class PreprocessingPipeline
+- __init__: sklearn.pipeline.Pipeline をラップするクラス
+
+Parameters
+----------
+steps : List[tuple[str, Transformer]]
+    sklearnと同様の形式で処理ステップを渡す
+- fit: 
+- transform: 
+- fit_transform: 
+- _validate_input: 
+- _check_is_fitted: 
+- get_pipeline: 内部のPipelineインスタンスを取得
+- get_feature_names_out: 最終ステップの出力カラム名を取得できる場合は取得
+

--- a/class_specs/trading/README.md
+++ b/class_specs/trading/README.md
@@ -1,0 +1,7 @@
+# trading のクラス仕様書
+
+## trading_facade.py
+
+### class TradingFacade
+- __init__: SBI取引操作を統括するファサード
+

--- a/class_specs/trading/jpx/README.md
+++ b/class_specs/trading/jpx/README.md
@@ -1,0 +1,13 @@
+# trading/jpx のクラス仕様書
+
+## loan_margins_list_getter.py
+
+### class _LoanMarginsFetcher
+- __init__: 
+
+### class _LoanMarginsProcessor
+- process_data: 
+
+### class LoanMarginsListGetter
+- __init__: 
+

--- a/class_specs/trading/sbi/browser/README.md
+++ b/class_specs/trading/sbi/browser/README.md
@@ -1,0 +1,21 @@
+# trading/sbi/browser のクラス仕様書
+
+## file_utils.py
+
+### class FileUtils
+- get_downloaded_csv: ダウンロードフォルダから最新のCSVファイルを取得
+- get_newest_two_csvs: ディレクトリ内の最新2つのファイルを取得
+
+## page_navigator.py
+
+### class PageNavigator
+- __init__: SBI証券のWebサイト上の各ページへの遷移を行います。
+browser_manager (SBIBrowserManager): ブラウザ及びタブの管理・操作を司ります。
+
+## sbi_browser_manager.py
+
+### class SBIBrowserManager
+- __init__: SBI証券向けのブラウザ操作を定義します。
+Args:
+    browser_manager (BrowserManager): ブラウザおよびタブの操作と管理を司ります。
+

--- a/class_specs/trading/sbi/common/interface/README.md
+++ b/class_specs/trading/sbi/common/interface/README.md
@@ -1,0 +1,7 @@
+# trading/sbi/common/interface のクラス仕様書
+
+## margin_provider.py
+
+### class IMarginProvider
+証拠金情報提供のインターフェース
+

--- a/class_specs/trading/sbi/common/provider/README.md
+++ b/class_specs/trading/sbi/common/provider/README.md
@@ -1,0 +1,11 @@
+# trading/sbi/common/provider のクラス仕様書
+
+## margin_provider.py
+
+### class SBIMarginProvider
+SBI証券から証拠金情報を提供するクラス
+- __init__: コンストラクタ
+
+Args:
+    browser_manager (SBIBrowserManager): SBI証券のブラウザセッションを管理するオブジェクト
+

--- a/class_specs/trading/sbi/operations/README.md
+++ b/class_specs/trading/sbi/operations/README.md
@@ -1,0 +1,69 @@
+# trading/sbi/operations のクラス仕様書
+
+## history_manager.py
+
+### class HistoryManager
+- __init__: 取引履歴管理クラス
+- _add_previous_mtext: 
+- _get_conract_summary_df: 
+- _format_contracts_df: 
+- _format_cashflow_transactions_df: 
+- _append_spot_to_list: 
+
+## position_manager.py
+
+### class PositionManager
+- __init__: ポジション管理クラス
+- _load_data: ポジションデータをCSVファイルから読み込む
+- _save_data: ポジションデータをCSVファイルに保存
+- _prepare_rows_for_csv: CSVに書き込むための行データを準備
+- _trade_params_to_dict: TradeParametersオブジェクトを辞書に変換
+- add_position: 新しいポジションを追加し、追加したポジションのインデックスを返す
+
+Args:
+    order_params (TradeParameters): 注文パラメータ
+    
+Returns:
+    int: 追加したポジションのインデックス
+- update_status: 特定のポジションのステータスを更新
+- status_type: 'order_status' または 'settlement_status'
+- find_unordered_position_by_params: 指定したパラメータのポジションのリスト内での位置を取得
+比較対象は'symbol_code', 'trade_type', 'unit'の3つ
+- update_order_id: 発注時IDを更新
+- update_by_symbol: 指定された銘柄コードに一致するレコードの特定フィールドを更新します。
+複数のレコードが一致した場合は、そのすべてに対して更新を行います。
+
+Args:
+    symbol_code (str): 更新対象レコードを選択するためのシンボルコード
+    update_key (str): 更新対象とするデータのキー
+    update_value (str | int | float): 更新対象とするデータの更新後の値
+
+Returns:
+    bool: 1件以上のレコードが更新された場合はTrue、更新対象がない場合はFalse
+- get_all_positions: 全ポジション情報を取得
+- get_pending_positions: 発注待ちのポジションを取得
+- order_status: '未発注'
+- settlement_status: '未発注'
+- get_open_positions: 決済発注待ちのポジションを取得
+- order_status: '発注済'
+- settlement_status: '未発注'
+- remove_waiting_order: 指定した注文IDのデータを削除
+
+## trade_parameters.py
+
+### class TradeParameters
+- validate_positive_price: 価格が正の数であることを確認
+- validate_period_value: 期間指定時に日付が設定されているかを確認
+- validate_order_type_value: order_typeに応じてorder_type_valueの選択肢を絞る
+- validate_limit_order_price: order_typeが指値のとき、limit_order_priceを必須入力とする
+- validate_stop_order_trigger_price: order_typeが逆指値の時、stop_order_trigger_priceを必須入力とする
+- validate_stop_order_price: order_typeが逆指値でstop_order_typeが指値のとき、stop_order_priceを必須入力とする
+- validate_period_value_or_index: period_typeが期間指定のとき、period_valueまたはperiod_indexのいずれかを必ず入力する
+
+## trade_possibility_manager.py
+
+### class TradePossibilityManager
+- __init__: 取引制限情報の管理クラス
+- _remove_files_in_download_folder: 
+- _convert_csv_to_df: 
+

--- a/class_specs/trading/sbi/orders/interface/README.md
+++ b/class_specs/trading/sbi/orders/interface/README.md
@@ -1,0 +1,13 @@
+# trading/sbi/orders/interface のクラス仕様書
+
+## order_executor.py
+
+### class OrderRequest
+注文リクエストのデータコンテナ
+
+### class OrderResult
+注文結果のデータコンテナ
+
+### class IOrderExecutor
+注文実行のインターフェース
+

--- a/class_specs/trading/sbi/orders/manager/README.md
+++ b/class_specs/trading/sbi/orders/manager/README.md
@@ -1,0 +1,8 @@
+# trading/sbi/orders/manager のクラス仕様書
+
+## order_executor.py
+
+### class SBIOrderExecutor
+SBI証券での注文実行を管理するクラス
+- __init__: 
+

--- a/class_specs/trading/sbi/orders/manager/components/README.md
+++ b/class_specs/trading/sbi/orders/manager/components/README.md
@@ -1,0 +1,31 @@
+# trading/sbi/orders/manager/components のクラス仕様書
+
+## base.py
+
+### class BaseExecutor
+Order executor base providing common utilities
+- __init__: 
+- _get_selector: 
+
+## canceller.py
+
+### class OrderCancellerMixin
+Handles order cancellation
+- _extract_order_row_data: 
+
+## fetcher.py
+
+### class OrderInfoFetcherMixin
+Fetches active orders and positions
+- _parse_positions_table: 
+
+## placer.py
+
+### class OrderPlacerMixin
+Handles order placement
+
+## settler.py
+
+### class PositionSettlerMixin
+Handles position settlement
+

--- a/class_specs/trading/sbi/orders/ordermaker/README.md
+++ b/class_specs/trading/sbi/orders/ordermaker/README.md
@@ -1,0 +1,22 @@
+# trading/sbi/orders/ordermaker のクラス仕様書
+
+## batch_order_maker.py
+
+### class BatchOrderMaker
+一括注文を行うクラス
+- _save_failed_orders: 失敗した注文をCSVに保存する
+
+## order_maker.py
+
+### class OrderMaker
+注文組立の基底クラス
+- __init__: 
+- create_order_request: 注文リクエストを作成する
+- _get_margin_trade_section: 信用取引区分を適正化する
+- _calculate_short_selling_limit_price: 空売り制限価格を計算する
+
+## position_settler.py
+
+### class PositionSettler
+ポジション決済を行うクラス
+

--- a/class_specs/trading/sbi/selection/README.md
+++ b/class_specs/trading/sbi/selection/README.md
@@ -1,0 +1,18 @@
+# trading/sbi/selection のクラス仕様書
+
+## one_stop_stock_selector.py
+
+### class OneStopStockSelector
+銘柄選択プロセスのためのファサードクラス。
+複数のコンポーネントの初期化と連携を簡略化します。
+- __init__: Args:
+    order_price_df: 価格データ
+    pred_result_df: 予測結果データ
+    browser_manager: ブラウザマネージャー
+    sector_definitions_path: セクター定義ファイルパス (省略時はデフォルト)
+    num_sectors_to_trade: 取引するセクター数
+    num_candidate_sectors: 候補セクター数
+    top_slope: トップセクターの傾斜
+- buy_sectors: 選択された買いセクターのリストを取得
+- sell_sectors: 選択された売りセクターのリストを取得
+

--- a/class_specs/trading/sbi/selection/analyzer/README.md
+++ b/class_specs/trading/sbi/selection/analyzer/README.md
@@ -1,0 +1,28 @@
+# trading/sbi/selection/analyzer のクラス仕様書
+
+## sector_analyzer.py
+
+### class SectorAnalyzer
+セクター分析クラス
+- analyze_sector_predictions: セクター予測を分析
+- select_sectors_to_trade: 取引対象セクターを選択
+
+## tradability_analyzer.py
+
+### class TradabilityAnalyzer
+取引可能性分析クラス
+- __init__: Args:
+    sector_provider: セクター情報プロバイダー
+    trade_limit_provider: 取引制限情報プロバイダー
+- _count_tradable_by_sector: セクターごとの取引可能銘柄数を集計
+- _count_total_by_sector: セクターごとの合計銘柄数を集計
+
+## weight_calculator.py
+
+### class WeightCalculator
+ウェイト計算クラス
+- calculate_weights: 銘柄ウェイトを計算
+- _calc_index_weight_components: 終値時点での単位株購入コスト、過去5営業日の出来高平均、時価総額を算出
+- _merge_sector_and_price_data: セクター情報と価格データを結合
+- _calculate_sector_weights: セクター内での銘柄ウェイトを計算
+

--- a/class_specs/trading/sbi/selection/interface/README.md
+++ b/class_specs/trading/sbi/selection/interface/README.md
@@ -1,0 +1,49 @@
+# trading/sbi/selection/interface のクラス仕様書
+
+## analyzer.py
+
+### class ISectorAnalyzer
+セクター分析インターフェース
+- analyze_sector_predictions: セクター予測を分析
+- select_sectors_to_trade: 取引対象セクターを選択
+
+### class IWeightCalculator
+ウェイト計算インターフェース
+- calculate_weights: 銘柄ウェイトを計算
+
+## dataclasses.py
+
+### class SectorPrediction
+セクター予測結果
+
+### class StockWeight
+銘柄ウェイト情報
+
+### class OrderUnit
+注文単位情報
+
+## portfolio.py
+
+### class IOrderAllocator
+注文配分インターフェース
+- allocate_orders: 注文を配分
+
+## provider.py
+
+### class ISectorProvider
+セクター情報提供インターフェース
+- get_sector_definitions: セクター定義情報を取得
+
+### class IPriceProvider
+価格情報提供インターフェース
+- get_price_data: 価格データを取得
+- get_etf_price: 指定したETFの価格を取得
+
+### class ITradeLimitProvider
+取引制限情報提供インターフェース
+
+## selector.py
+
+### class IStockSelector
+銘柄選択インターフェース
+

--- a/class_specs/trading/sbi/selection/portfolio/README.md
+++ b/class_specs/trading/sbi/selection/portfolio/README.md
@@ -1,0 +1,33 @@
+# trading/sbi/selection/portfolio のクラス仕様書
+
+## etf_allocator.py
+
+### class ETFAllocator
+ETF配分クラス
+- __init__: Args:
+    price_provider: 価格情報プロバイダー
+- allocate_etfs: ETFを配分
+
+## order_allocator.py
+
+### class OrderAllocator
+注文配分クラス
+- __init__: Args:
+    unit_calculator: 注文単位計算
+    etf_allocator: ETF配分
+- allocate_orders: 注文を配分
+- allocate_balanced_orders: 買い・売りのバランスをとった注文を配分
+
+## unit_calculator.py
+
+### class UnitCalculator
+注文単位計算クラス
+- __init__: 
+- calculate_units: 注文単位数を計算
+- _get_ideal_costs: 理想コストを計算
+- _draft_portfolio: 仮ポートフォリオを作成
+- _reduce_to_max_unit: 最大単位数に制限
+- _reduce_units: 予算内に抑える
+- _increase_units: 予算を最大限活用
+- _calculate_price_limits: 価格上限を計算
+

--- a/class_specs/trading/sbi/selection/provider/README.md
+++ b/class_specs/trading/sbi/selection/provider/README.md
@@ -1,0 +1,25 @@
+# trading/sbi/selection/provider のクラス仕様書
+
+## price_provider.py
+
+### class PriceProvider
+価格情報提供クラス
+- __init__: Args:
+    order_price_df: 注文価格データフレーム
+- get_price_data: 価格データを取得
+- get_etf_price: 指定したETFの価格を取得
+
+## sector_provider.py
+
+### class SectorProvider
+セクター情報提供クラス
+- __init__: Args:
+    sector_definitions_csv: セクター定義CSVファイルのパス
+- get_sector_definitions: セクター定義情報を取得
+
+## trade_limit_provider.py
+
+### class TradeLimitProvider
+取引制限情報提供クラス
+- __init__: 
+

--- a/class_specs/trading/sbi/selection/selector/README.md
+++ b/class_specs/trading/sbi/selection/selector/README.md
@@ -1,0 +1,21 @@
+# trading/sbi/selection/selector のクラス仕様書
+
+## stock_selector.py
+
+### class StockSelector
+銘柄選択クラス
+- __init__: Args:
+    pred_result_df: 予測結果データフレーム
+    sector_provider: セクター情報プロバイダー
+    price_provider: 価格情報プロバイダー
+    trade_limit_provider: 取引制限情報プロバイダー
+    sector_analyzer: セクター分析
+    weight_calculator: ウェイト計算
+    order_allocator: 注文配分
+    num_sectors_to_trade: 取引するセクター数
+    num_candidate_sectors: 候補セクター数
+    top_slope: トップセクターの傾斜
+- _get_todays_pred_df: 最新日の予測結果を取得
+- _convert_orders_to_dataframe: 注文をデータフレームに変換
+- _save_orders_to_csv: 注文をCSVに保存
+

--- a/class_specs/trading/sbi_trading_logic/README.md
+++ b/class_specs/trading/sbi_trading_logic/README.md
@@ -1,0 +1,26 @@
+# trading/sbi_trading_logic のクラス仕様書
+
+## history_updater.py
+
+### class HistoryUpdater
+- __init__: 
+- load_information: 取引情報、買付余力、総入金額を更新せず読み込み
+returns:
+    pd.DataFrame: 過去の取引履歴
+    pd.DataFrame: 信用建余力の履歴
+    pd.DataFrame: 入出金の履歴
+    float: 直近の損益額
+    str: 直近の損益率
+- _show_latest_result: 
+
+## price_limit_calculator.py
+
+### class PriceLimitCalculator
+東京証券取引所の値幅制限に基づいて上限価格・下限価格を計算するクラス
+- __init__: 
+- get_price_limit: 基準値段から制限値幅を取得する
+- calculate_price_limits: 基準値段から上限価格と下限価格を計算する
+- calculate_upper_limit: 基準値段から上限価格を計算する
+- calculate_lower_limit: 基準値段から下限価格を計算する
+- calculate_for_stocks: 複数銘柄の上限価格と下限価格を計算する
+

--- a/class_specs/utils/browser/README.md
+++ b/class_specs/utils/browser/README.md
@@ -1,0 +1,46 @@
+# utils/browser のクラス仕様書
+
+## browser_manager.py
+
+### class BrowserManager
+ブラウザセッション全体を管理し、NamedTab を用いて複数タブを名前で管理するクラス
+- __init__: 
+- get_tab: 指定した名前のタブを取得する。
+
+Args:
+    name (str): 取得したいタブの識別名。
+
+Returns:
+    NamedTab | None: 取得した NamedTab インスタンス。存在しない場合は None。
+- rename_tab: 指定したタブの名前を変更する。
+
+Args:
+    name (str): 変更前のタブ名。
+    new_name (str): 変更後のタブ名。
+
+## browser_utils.py
+
+### class BrowserUtils
+ブラウザ全体の基本操作（起動、再利用、リセットなど）を提供するクラス
+
+## named_tab.py
+
+### class NamedTab
+タブの名前とその管理オブジェクト（TabManager）を保持するデータクラス
+
+## tab_manager.py
+
+### class TabManager
+タブのライフサイクル管理を行い、内部で TabUtils を保持するクラス
+- __init__: 
+- tab: nodriverの Tab インスタンスを返す
+- utils: タブ上の操作を提供する TabUtils インスタンスを返す
+
+## tab_utils.py
+
+### class TabUtils
+nodriver の Tab オブジェクトに対する操作（URLオープン、リロード、クリック等）をラップするユーティリティクラス
+Node document エラー対応版
+- __init__: Args:
+    tab (nodriver.Tab): nodriverのタブオブジェクト
+

--- a/class_specs/utils/jquants_api_utils/README.md
+++ b/class_specs/utils/jquants_api_utils/README.md
@@ -1,0 +1,7 @@
+# utils/jquants_api_utils のクラス仕様書
+
+## client.py
+
+### class Cli
+- __init__: 
+

--- a/class_specs/utils/metadata/README.md
+++ b/class_specs/utils/metadata/README.md
@@ -1,0 +1,12 @@
+# utils/metadata のクラス仕様書
+
+## feature_metadata.py
+
+### class FeatureMetadata
+時系列データ取得用の特徴量メタデータを定義します。
+name (str): 特徴量名
+group (str): 特徴量グループ（commodity, currencyなど）
+parquet_path (str): 時系列データ保存先のparquetファイルパス
+url (str): 時系列データ取得元のURL
+is_adopted (bool): 特徴量として採用するかどうか
+

--- a/class_specs/utils/notifier/README.md
+++ b/class_specs/utils/notifier/README.md
@@ -1,0 +1,24 @@
+# utils/notifier のクラス仕様書
+
+## slack_notifier.py
+
+### class SlackNotifier
+- __init__: 
+- send_message: SLACKにメッセージを送ります。
+Args:
+    message (str): 送信するメッセージ
+    channel (str): 送信先のチャンネルID (NoneのときはGeneralが指定される)
+- send_error_log: SLACKにエラーログを送ります。
+Args:
+    message (str): 送信するメッセージ
+- send_result: SLACKに当日の結果を送ります。
+Args:
+    message (str): 送信するメッセージ
+- start: SLACKにプログラム開始メッセージを送ります。
+Args:
+    message (str): 送信するメッセージ
+    should_send_program_name (bool): メッセージにプログラム名を含めるか
+- finish: SLACKにプログラム終了メッセージを送ります。
+Args:
+    message (str): 送信するメッセージ
+

--- a/class_specs/utils/paths/README.md
+++ b/class_specs/utils/paths/README.md
@@ -1,0 +1,6 @@
+# utils/paths のクラス仕様書
+
+## paths.py
+
+### class Paths
+

--- a/class_specs/utils/singleton/README.md
+++ b/class_specs/utils/singleton/README.md
@@ -1,0 +1,8 @@
+# utils/singleton のクラス仕様書
+
+## singleton.py
+
+### class SingletonMeta
+シングルトン実現用メタクラス（スレッドセーフ）
+- __call__: 
+

--- a/class_specs/utils/timekeeper/README.md
+++ b/class_specs/utils/timekeeper/README.md
@@ -1,0 +1,12 @@
+# utils/timekeeper のクラス仕様書
+
+## timekeeper.py
+
+### class Timer
+実行時間を手動で測定するためのシンプルなタイマークラス。
+- __init__: 
+- start: タイマーを開始する。
+- stop: タイマーを停止する。
+- elapsed_time: 経過時間を計算する。
+- reset: タイマーをリセットする。
+

--- a/class_specs/utils/yaml_utils/README.md
+++ b/class_specs/utils/yaml_utils/README.md
@@ -1,0 +1,24 @@
+# utils/yaml_utils のクラス仕様書
+
+## column_configs_getter.py
+
+### class ColumnConfigsGetter
+- __init__: 初期化処理として、YAML ファイルを読み込む。
+
+Args:
+    cols_yaml_path (str): YAML ファイルのパス
+- get_any_column_info: YAML ファイルから読み込んだリストを検索し、特定のキーに対応する値を取得する。
+
+Args:
+    key (str): 検索対象とするキーの値
+    info_name (str): 取得する要素名
+
+Returns:
+    str | None: 検索条件に一致する要素の `target_key` の値 (見つからなかった場合は `None`)
+- get_all_columns_info_asdict: 
+- get_column_name: 
+- get_column_names: 
+- get_all_columns_name_asdict: 
+- get_column_dtype: 
+- get_column_dtypes: 
+

--- a/generate_class_docs.py
+++ b/generate_class_docs.py
@@ -1,0 +1,51 @@
+import os
+import ast
+from pathlib import Path
+
+BASE_DIR = Path('project/modules')
+DOC_BASE = Path('class_specs')
+
+for root, _, files in os.walk(BASE_DIR):
+    classes_per_file = {}
+    for file in files:
+        if not file.endswith('.py'):
+            continue
+        path = Path(root) / file
+        try:
+            source = path.read_text(encoding='utf-8')
+        except Exception:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        classes = []
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                cls_doc = ast.get_docstring(node) or ''
+                methods = []
+                for n in node.body:
+                    if isinstance(n, ast.FunctionDef):
+                        method_doc = ast.get_docstring(n) or ''
+                        methods.append((n.name, method_doc))
+                classes.append({'name': node.name, 'doc': cls_doc, 'methods': methods})
+        if classes:
+            classes_per_file[file] = classes
+    if not classes_per_file:
+        continue
+    rel_dir = Path(root).relative_to(BASE_DIR)
+    doc_dir = DOC_BASE / rel_dir
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    doc_file = doc_dir / 'README.md'
+    with open(doc_file, 'w', encoding='utf-8') as f:
+        f.write(f'# {rel_dir} のクラス仕様書\n\n')
+        for file_name, classes in sorted(classes_per_file.items()):
+            f.write(f'## {file_name}\n\n')
+            for cls in classes:
+                f.write(f'### class {cls["name"]}\n')
+                if cls['doc']:
+                    f.write(cls['doc'] + '\n')
+                for m_name, m_doc in cls['methods']:
+                    f.write(f'- {m_name}: {m_doc}\n')
+                f.write('\n')
+print('Documentation generated in', DOC_BASE)


### PR DESCRIPTION
## Summary
- add script to auto-generate class documentation per directory
- run script to create initial class specs under `class_specs/`

## Testing
- `python3 generate_class_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_684cccaaad4c83328617ca5d574f85b2