### PR TITLE
Add multi-model LASSO execution

### DIFF
--- a/project/execution_scripts/current_files/PO48_54_Lasso.py
+++ b/project/execution_scripts/current_files/PO48_54_Lasso.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import asyncio
+
+from utils.notifier import SlackNotifier
+from utils.paths import Paths
+from facades import DataUpdateFacade, ModeForStrategy
+from facades import MultiModelOrderExecutionFacade, ModelOrderConfig
+from trading import TradingFacade
+
+async def main() -> None:
+    slack = SlackNotifier(program_name=os.path.basename(__file__))
+    slack.start(message='プログラムを開始します。', should_send_program_name=True)
+
+    # パラメータ設定
+    datasets_48 = f"{Paths.ML_DATASETS_FOLDER}/48sectors_LASSO_learned_in_250615"
+    datasets_54 = f"{Paths.ML_DATASETS_FOLDER}/54sectors_LASSO_learned_in_250623"
+    sector_csv_48 = f"{Paths.SECTOR_REDEFINITIONS_FOLDER}/48sectors_2024-2025.csv"
+    sector_csv_54 = f"{Paths.SECTOR_REDEFINITIONS_FOLDER}/54sectors_2024-2025.csv"
+    universe_filter = "(Listing==1)&((ScaleCategory=='TOPIX Core30')|(ScaleCategory=='TOPIX Large70')|(ScaleCategory=='TOPIX Mid400')|(ScaleCategory=='TOPIX Small 1'))"
+    trading_sector_num = 2
+    candidate_sector_num = 4
+    top_slope = 1
+
+    try:
+        modes = ModeForStrategy.generate_mode()
+        data_facade = DataUpdateFacade(mode=modes.data_update_mode, universe_filter=universe_filter)
+        await data_facade.execute()
+
+        trade_facade = TradingFacade()
+        configs = [
+            ModelOrderConfig(
+                dataset_path=datasets_48,
+                sector_csv=sector_csv_48,
+                trading_sector_num=trading_sector_num,
+                candidate_sector_num=candidate_sector_num,
+                top_slope=top_slope,
+                margin_weight=0.5,
+            ),
+            ModelOrderConfig(
+                dataset_path=datasets_54,
+                sector_csv=sector_csv_54,
+                trading_sector_num=trading_sector_num,
+                candidate_sector_num=candidate_sector_num,
+                top_slope=top_slope,
+                margin_weight=0.5,
+            ),
+        ]
+
+        order_facade = MultiModelOrderExecutionFacade(
+            mode=modes.order_execution_mode,
+            trade_facade=trade_facade,
+            configs=configs,
+        )
+        await order_facade.execute()
+
+        slack.finish(message='すべての処理が完了しました。')
+    except Exception:
+        from utils.error_handler import error_handler
+        error_handler.handle_exception(Paths.ERROR_LOG_CSV)
+        slack.send_error_log(f"エラーが発生しました。\n詳細は{Paths.ERROR_LOG_CSV}を確認してください。")
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())
+

--- a/project/modules/facades/__init__.py
+++ b/project/modules/facades/__init__.py
@@ -3,6 +3,10 @@ from .sector_ml_datasets_facade import SectorMLDatasetsFacade
 from .data_pipeline.data_update_facade import DataUpdateFacade
 from .data_pipeline.machine_learning_facade import MachineLearningFacade
 from .data_pipeline.order_execution_facade import OrderExecutionFacade
+from .data_pipeline.multi_model_order_facade import (
+    MultiModelOrderExecutionFacade,
+    ModelOrderConfig,
+)
 from .data_pipeline.trade_data_facade import TradeDataFacade
 from .mode_setting import ModeCollection, ModeFactory, ModeForStrategy
 
@@ -12,6 +16,8 @@ __all__ = [
     'DataUpdateFacade',
     'MachineLearningFacade',
     'OrderExecutionFacade',
+    'MultiModelOrderExecutionFacade',
+    'ModelOrderConfig',
     'TradeDataFacade',
     'ModeCollection',
     'ModeFactory',

--- a/project/modules/facades/data_pipeline/__init__.py
+++ b/project/modules/facades/data_pipeline/__init__.py
@@ -1,12 +1,15 @@
 from .data_update_facade import DataUpdateFacade
 from .machine_learning_facade import MachineLearningFacade
 from .order_execution_facade import OrderExecutionFacade
+from .multi_model_order_facade import MultiModelOrderExecutionFacade, ModelOrderConfig
 from .trade_data_facade import TradeDataFacade
 
 __all__ = [
     'DataUpdateFacade',
     'MachineLearningFacade',
     'OrderExecutionFacade',
+    'MultiModelOrderExecutionFacade',
+    'ModelOrderConfig',
     'TradeDataFacade',
 ]
 

--- a/project/modules/facades/data_pipeline/multi_model_order_facade.py
+++ b/project/modules/facades/data_pipeline/multi_model_order_facade.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Literal
+
+from models.machine_learning.loaders import DatasetLoader
+from trading import TradingFacade
+from models.machine_learning.models import LassoModel
+from models.machine_learning.ml_dataset import MLDatasets, SingleMLDataset
+
+@dataclass
+class ModelOrderConfig:
+    dataset_path: str
+    sector_csv: str
+    trading_sector_num: int
+    candidate_sector_num: int
+    top_slope: float
+    margin_weight: float = 0.5
+
+class MultiModelOrderExecutionFacade:
+    """複数モデルの予測結果を用いた発注を管理するファサード"""
+
+    def __init__(self, mode: Literal['new', 'none'], trade_facade: TradingFacade, configs: List[ModelOrderConfig]):
+        self.mode = mode
+        self.trade_facade = trade_facade
+        self.configs = configs
+
+    def _predict_lasso(self, dataset_path: str) -> MLDatasets:
+        """LASSOモデルで予測を実行し ``MLDatasets`` を返す"""
+        loader = DatasetLoader(dataset_path)
+        ml_datasets = loader.load_datasets()
+        model = LassoModel()
+        for _, single_ml in ml_datasets.items():
+            pred_df = model.predict(
+                single_ml.train_test_materials.target_test_df,
+                single_ml.train_test_materials.features_test_df,
+                single_ml.ml_object_materials.model,
+                single_ml.ml_object_materials.scaler,
+            )
+            single_ml.archive_pred_result(pred_df)
+            single_ml.save()
+            ml_datasets.replace_model(single_ml_dataset=single_ml)
+        return ml_datasets
+
+    async def execute(self) -> None:
+        if self.mode == 'none':
+            return
+        if self.mode != 'new':
+            raise NotImplementedError("現在のところ 'new' モードのみ対応しています。")
+
+        await self.trade_facade.margin_provider.refresh()
+        total_margin = await self.trade_facade.margin_provider.get_available_margin()
+
+        for cfg in self.configs:
+            ml_datasets = self._predict_lasso(cfg.dataset_path)
+            alloc_margin = total_margin * cfg.margin_weight
+            await self.trade_facade.take_positions(
+                order_price_df=ml_datasets.get_order_price(),
+                pred_result_df=ml_datasets.get_pred_result(),
+                SECTOR_REDEFINITIONS_CSV=cfg.sector_csv,
+                num_sectors_to_trade=cfg.trading_sector_num,
+                num_candidate_sectors=cfg.candidate_sector_num,
+                top_slope=cfg.top_slope,
+                margin_power=alloc_margin,
+            )
+

--- a/project/modules/trading/trading_facade.py
+++ b/project/modules/trading/trading_facade.py
@@ -36,13 +36,14 @@ class TradingFacade:
         
         self.Paths = Paths
 
-    async def take_positions(self, 
+    async def take_positions(self,
                              order_price_df: pd.DataFrame,
                              pred_result_df: pd.DataFrame,
-                             SECTOR_REDEFINITIONS_CSV: str, 
-                             num_sectors_to_trade: int = 3, 
-                             num_candidate_sectors: int = 5, 
-                             top_slope: float = 1.0):
+                             SECTOR_REDEFINITIONS_CSV: str,
+                             num_sectors_to_trade: int = 3,
+                             num_candidate_sectors: int = 5,
+                             top_slope: float = 1.0,
+                             margin_power: float | None = None):
         '''
         信用新規建を行います。
         Args:
@@ -64,7 +65,7 @@ class TradingFacade:
                                               num_candidate_sectors = num_candidate_sectors,
                                               top_slope = top_slope)
         
-        orders_df, _ = await stock_selector.select_stocks()
+        orders_df, _ = await stock_selector.select_stocks(margin_power)
         
         # 注文一括発注
         results = await self.batch_order_maker.place_batch_orders(orders_df)


### PR DESCRIPTION
## Summary
- add a facade to handle multiple LASSO models for trading
- allow specifying margin allocation with `MultiModelOrderExecutionFacade`
- extend `TradingFacade.take_positions` with optional `margin_power`
- export new facade classes
- add execution script `PO48_54_Lasso.py`

## Testing
- `pytest -q` *(fails: pyenv version not installed)*
- `black` *(fails: pyenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858d84f7e6c8332aaa98fa828542d47