### PR TITLE
Fix failed order CSV index issue

### DIFF
--- a/project/modules/trading/sbi/orders/ordermaker/batch_order_maker.py
+++ b/project/modules/trading/sbi/orders/ordermaker/batch_order_maker.py
@@ -86,4 +86,5 @@ class BatchOrderMaker(OrderMaker):
             return
         self.failed_orders = list(map(str, self.failed_orders))
         failed_orders_df = orders_df.loc[orders_df['Code'].astype(str).isin(self.failed_orders), :]
-        failed_orders_df.to_csv(Paths.FAILED_ORDERS_CSV)
+        # インデックス列が不要なため、index=Falseで保存する
+        failed_orders_df.to_csv(Paths.FAILED_ORDERS_CSV, index=False)


### PR DESCRIPTION
## Summary
- avoid accumulating index columns in `failed_list.csv`

## Testing
- `find project -name '*.py' -print0 | xargs -0 python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685a700d75708332821f7dff77767879