### PR TITLE
Update default orders path usage

### DIFF
--- a/project/execution_scripts/current_files/PO48Ensemble copy.py
+++ b/project/execution_scripts/current_files/PO48Ensemble copy.py
@@ -83,9 +83,10 @@ async def main() -> None:
         await order_facade.execute(config)
 
         # 4. 取引データの取得
-        trade_data_facade = TradeDataFacade(mode=modes.trade_data_fetch_mode, 
-                                            trade_facade=trading_facade,
-                                            sector_csv=sector_redef_csv)
+        trade_data_facade = TradeDataFacade(
+            mode=modes.trade_data_fetch_mode,
+            trade_facade=trading_facade,
+        )
         await trade_data_facade.execute()
 
         slack.finish(message='すべての処理が完了しました。')

--- a/project/execution_scripts/current_files/PO48Ensemble.py
+++ b/project/execution_scripts/current_files/PO48Ensemble.py
@@ -82,9 +82,10 @@ async def main() -> None:
         await order_facade.execute(config)
 
         # 4. 取引データの取得
-        trade_data_facade = TradeDataFacade(mode=modes.trade_data_fetch_mode, 
-                                            trade_facade=trading_facade,
-                                            sector_csv=sector_redef_csv)
+        trade_data_facade = TradeDataFacade(
+            mode=modes.trade_data_fetch_mode,
+            trade_facade=trading_facade,
+        )
         await trade_data_facade.execute()
 
         slack.finish(message='すべての処理が完了しました。')

--- a/project/execution_scripts/current_files/PO48Ensembler inverse_after_pred.py
+++ b/project/execution_scripts/current_files/PO48Ensembler inverse_after_pred.py
@@ -87,9 +87,10 @@ async def main() -> None:
         await order_facade.execute(config)
 
         # 4. 取引データの取得
-        trade_data_facade = TradeDataFacade(mode=modes.trade_data_fetch_mode, 
-                                            trade_facade=trading_facade,
-                                            sector_csv=sector_redef_csv)
+        trade_data_facade = TradeDataFacade(
+            mode=modes.trade_data_fetch_mode,
+            trade_facade=trading_facade,
+        )
         await trade_data_facade.execute()
 
         slack.finish(message='すべての処理が完了しました。')

--- a/project/execution_scripts/current_files/PO48Ensembler raw.py
+++ b/project/execution_scripts/current_files/PO48Ensembler raw.py
@@ -77,7 +77,7 @@ async def main() -> None:
         )
         config = ModelOrderConfig(
             ml_datasets=ensembled_dataset,
-            sector_csv=sector_redef_csv,
+
             trading_sector_num=trading_sector_num,
             candidate_sector_num=candidate_sector_num,
             top_slope=top_slope,
@@ -86,9 +86,10 @@ async def main() -> None:
         await order_facade.execute(config)
 
         # 4. 取引データの取得
-        trade_data_facade = TradeDataFacade(mode=modes.trade_data_fetch_mode, 
-                                            trade_facade=trading_facade,
-                                            sector_csv=sector_redef_csv)
+        trade_data_facade = TradeDataFacade(
+            mode=modes.trade_data_fetch_mode,
+            trade_facade=trading_facade,
+        )
         await trade_data_facade.execute()
 
         slack.finish(message='すべての処理が完了しました。')

--- a/project/execution_scripts/current_files/PO48_54_Lasso.py
+++ b/project/execution_scripts/current_files/PO48_54_Lasso.py
@@ -86,7 +86,6 @@ async def main() -> None:
         trade_data_facade = TradeDataFacade(
             mode=modes.trade_data_fetch_mode,
             trade_facade=trade_facade,
-            sector_csv=sector_csv_2nd_model,
         )
         await trade_data_facade.execute()
         

--- a/project/execution_scripts/current_files/PO54Ensemble.py
+++ b/project/execution_scripts/current_files/PO54Ensemble.py
@@ -84,9 +84,10 @@ async def main() -> None:
         await order_facade.execute(config)
 
         # 4. 取引データの取得
-        trade_data_facade = TradeDataFacade(mode=modes.trade_data_fetch_mode, 
-                                            trade_facade=trading_facade,
-                                            sector_csv=sector_redef_csv)
+        trade_data_facade = TradeDataFacade(
+            mode=modes.trade_data_fetch_mode,
+            trade_facade=trading_facade,
+        )
         await trade_data_facade.execute()
 
         slack.finish(message='すべての処理が完了しました。')

--- a/project/modules/facades/data_pipeline/trade_data_facade.py
+++ b/project/modules/facades/data_pipeline/trade_data_facade.py
@@ -2,28 +2,30 @@ from __future__ import annotations
 
 from typing import Literal
 
+from utils.paths import Paths
+
 from trading import TradingFacade
 
 
 class TradeDataFacade:
     """取引データを取得するコード"""
 
-    def __init__(self, mode: Literal['fetch', 'none'], trade_facade: TradingFacade, sector_csv: str) -> None:
+    def __init__(self, mode: Literal['fetch', 'none'], trade_facade: TradingFacade, orders_csv: str = Paths.ORDERS_CSV) -> None:
         self.mode = mode
         self.trade_facade = trade_facade
-        self.sector_csv = sector_csv
+        self.orders_csv = orders_csv
 
     async def execute(self) -> None:
         if self.mode == 'fetch':
-            await self.trade_facade.fetch_invest_result(self.sector_csv)
+            await self.trade_facade.fetch_invest_result(self.orders_csv)
 
 
 if __name__ == '__main__':
     from utils.paths import Paths
     import asyncio
+
     async def main():
-        SECTOR_CSV = f'{Paths.SECTOR_REDEFINITIONS_FOLDER}/48sectors_2024-2025.csv'
-        tdf = TradeDataFacade(mode='fetch', trade_facade=TradingFacade(), sector_csv=SECTOR_CSV)
+        tdf = TradeDataFacade(mode='fetch', trade_facade=TradingFacade())
         await tdf.execute()
     
     asyncio.get_event_loop().run_until_complete(main())

--- a/project/modules/trading/trading_facade.py
+++ b/project/modules/trading/trading_facade.py
@@ -197,11 +197,11 @@ class TradingFacade:
             failed_messages = "\n".join([f"{order.message}" for order in failed_settlements])
             self.slack.send_message(f'以下の銘柄の決済注文に失敗しました。\n{failed_messages}')
 
-    async def fetch_invest_result(self, SECTOR_REDEFINITIONS_CSV):
+    async def fetch_invest_result(self, ORDERS_CSV_PATH: str = Paths.ORDERS_CSV):
         '''
         当日の取引履歴・入出金履歴・買付余力を取得します。
         '''
-        history_updater = HistoryUpdater(self.history_manager, self.margin_provider, SECTOR_REDEFINITIONS_CSV)
+        history_updater = HistoryUpdater(self.history_manager, self.margin_provider, ORDERS_CSV_PATH)
         trade_history, _, _, _, amount = await history_updater.update_information()
         self.slack.send_result(f'取引履歴等の更新が完了しました。\n{trade_history["日付"].iloc[-1].strftime("%Y-%m-%d")}の取引結果：{amount}円')
 


### PR DESCRIPTION
## Summary
- remove redundant orders_csv arg in trading scripts
- use default path in sample modules
- simplify history_manager example

## Testing
- `pytest -q` *(fails: pyenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a7a3f43d88332af859390ffadaecc