### PR TITLE
Add Japanese metric names

### DIFF
--- a/project/execution_scripts/run_prediction_analysis.py
+++ b/project/execution_scripts/run_prediction_analysis.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from modules.performance import PredictionReturnExecutor
+
+
+def main() -> None:
+    dates = pd.date_range("2024-01-01", periods=30)
+    predicted = pd.Series(np.random.randn(len(dates)) / 100, index=dates)
+    actual = pd.Series(np.random.randn(len(dates)) / 100, index=dates)
+
+    executor = PredictionReturnExecutor(predicted, actual)
+    result = executor.execute()
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/project/modules/performance/__init__.py
+++ b/project/modules/performance/__init__.py
@@ -1,0 +1,21 @@
+from .transformations import TaxRate, Leverage
+from .annualizer import Annualizer
+from .metrics import (
+    EvaluationMetric,
+    AggregateMetric,
+    SeriesMetric,
+    RankMetric,
+    ExpectedReturn,
+    StandardDeviationOfReturn,
+    SharpeRatio,
+    MaxDrawdown,
+    TheoreticalMaxDrawdown,
+    SpearmanCorrelation,
+    EvaluationMetricsManager,
+)
+from .analyzers import (
+    ReturnSeriesTransformer,
+    PredictionReturnAnalyzer,
+    TradeResultAnalyzer,
+)
+from .executor import PredictionReturnExecutor

--- a/project/modules/performance/analyzers.py
+++ b/project/modules/performance/analyzers.py
@@ -1,0 +1,96 @@
+"""リターン評価アナライザー"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+
+from .transformations import TaxRate, Leverage
+from .annualizer import Annualizer
+from .metrics import EvaluationMetricsManager, SpearmanCorrelation
+
+
+@dataclass
+class ReturnSeriesTransformer:
+    """リターン系列の変換を扱うクラス"""
+
+    tax_rate_obj: TaxRate
+    leverage_obj: Leverage
+
+    def get_pre_tax_pre_leverage_returns(self, raw_returns: pd.Series) -> pd.Series:
+        return raw_returns
+
+    def get_pre_tax_post_leverage_returns(self, raw_returns: pd.Series) -> pd.Series:
+        return self.leverage_obj.apply_leverage(raw_returns)
+
+    def get_post_tax_post_leverage_returns(self, raw_returns: pd.Series) -> pd.Series:
+        leveraged = self.leverage_obj.apply_leverage(raw_returns)
+        return self.tax_rate_obj.apply_tax(leveraged)
+
+    def get_pre_tax_pre_leverage_from_post_tax_post_leverage(self, post_tax_post_leverage_returns: pd.Series) -> pd.Series:
+        untaxed = self.tax_rate_obj.remove_tax(post_tax_post_leverage_returns)
+        return self.leverage_obj.remove_leverage(untaxed)
+
+
+class PredictionReturnAnalyzer:
+    """予測リターンと実際のリターンを評価するクラス"""
+
+    def __init__(self, raw_predicted_returns: pd.Series, actual_returns: pd.Series,
+                 transformer: ReturnSeriesTransformer, evaluation_manager: EvaluationMetricsManager) -> None:
+        if not raw_predicted_returns.index.equals(actual_returns.index):
+            raise ValueError("インデックスが一致していません")
+        self.raw_predicted = raw_predicted_returns
+        self.actual = actual_returns
+        self.transformer = transformer
+        self.manager = evaluation_manager
+
+    def run_analysis(self) -> pd.DataFrame:
+        patterns = {
+            "PreTax_PreLeverage": self.transformer.get_pre_tax_pre_leverage_returns,
+            "PostTax_PostLeverage": self.transformer.get_post_tax_post_leverage_returns,
+        }
+        dfs = {}
+        for name, func in patterns.items():
+            transformed = func(self.raw_predicted)
+            result = self.manager.evaluate_all(transformed)
+            # 相関は別途計算し平均値を格納
+            corr_metric = SpearmanCorrelation()
+            corr_df = corr_metric.calculate(transformed, series2=self.actual)
+            corr_mean = float("nan")
+            if "SpearmanCorr" in corr_df.index:
+                corr_mean = corr_df.loc["SpearmanCorr", "mean"]
+            result[corr_metric.get_name()] = corr_mean
+            dfs[name] = pd.Series(result)
+        return pd.DataFrame(dfs)
+
+
+class TradeResultAnalyzer:
+    """実際の取引結果を評価するクラス"""
+
+    def __init__(self, raw_trade_df: pd.DataFrame, transformer: ReturnSeriesTransformer,
+                 evaluation_manager: EvaluationMetricsManager) -> None:
+        if not {"Date", "Symbol", "DailyReturn"}.issubset(raw_trade_df.columns):
+            raise ValueError("必要なカラムが存在しません")
+        self.raw_trade_df = raw_trade_df.copy()
+        self.raw_trade_df["Date"] = pd.to_datetime(self.raw_trade_df["Date"])
+        self.transformer = transformer
+        self.manager = evaluation_manager
+
+    def run_analysis(self) -> Dict[str, pd.DataFrame]:
+        grouped = self.raw_trade_df.groupby("Symbol")
+        pre_results = {}
+        post_results = {}
+        for symbol, df in grouped:
+            series = df.sort_values("Date")["DailyReturn"]
+            post_tax_post_lev = series
+            pre_tax_pre_lev = self.transformer.get_pre_tax_pre_leverage_from_post_tax_post_leverage(series)
+            pre_results[symbol] = pd.Series(self.manager.evaluate_all(pre_tax_pre_lev))
+            post_results[symbol] = pd.Series(self.manager.evaluate_all(self.transformer.get_post_tax_post_leverage_returns(pre_tax_pre_lev)))
+        pre_df = pd.DataFrame(pre_results).T
+        post_df = pd.DataFrame(post_results).T
+        return {
+            "PreTax_PreLeverage": pre_df,
+            "PostTax_PostLeverage": post_df,
+        }

--- a/project/modules/performance/annualizer.py
+++ b/project/modules/performance/annualizer.py
@@ -1,0 +1,20 @@
+"""年次換算用ユーティリティ"""
+
+from __future__ import annotations
+
+import math
+
+
+class Annualizer:
+    """日次リターンやボラティリティを年次換算するクラス。"""
+
+    def __init__(self, trading_days_per_year: int = 252) -> None:
+        self.trading_days_per_year = trading_days_per_year
+
+    def annualize_return(self, daily_return: float) -> float:
+        """日次リターンを年率換算する。"""
+        return (1 + daily_return) ** self.trading_days_per_year - 1
+
+    def annualize_volatility(self, daily_volatility: float) -> float:
+        """日次ボラティリティを年率換算する。"""
+        return daily_volatility * math.sqrt(self.trading_days_per_year)

--- a/project/modules/performance/executor.py
+++ b/project/modules/performance/executor.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .transformations import TaxRate, Leverage
+from .annualizer import Annualizer
+from .metrics import (
+    ExpectedReturn,
+    StandardDeviationOfReturn,
+    SharpeRatio,
+    MaxDrawdown,
+    TheoreticalMaxDrawdown,
+    EvaluationMetricsManager,
+)
+from .analyzers import ReturnSeriesTransformer, PredictionReturnAnalyzer
+
+
+class PredictionReturnExecutor:
+    """PredictionReturnAnalyzer を簡易に実行するクラス"""
+
+    def __init__(
+        self,
+        predicted_returns: pd.Series,
+        actual_returns: pd.Series,
+        tax_rate: float = 0.20315,
+        leverage_ratio: float = 3.1,
+        trading_days_per_year: int = 252,
+    ) -> None:
+        if not predicted_returns.index.equals(actual_returns.index):
+            raise ValueError("インデックスが一致していません")
+        self.predicted_returns = predicted_returns
+        self.actual_returns = actual_returns
+        self.tax_rate_obj = TaxRate(tax_rate)
+        self.leverage_obj = Leverage(leverage_ratio)
+        self.annualizer = Annualizer(trading_days_per_year)
+        self.manager = EvaluationMetricsManager(self.annualizer)
+        self.manager.add_metric(ExpectedReturn())
+        self.manager.add_metric(StandardDeviationOfReturn())
+        self.manager.add_metric(SharpeRatio())
+        self.manager.add_metric(MaxDrawdown())
+        self.manager.add_metric(TheoreticalMaxDrawdown())
+        self.transformer = ReturnSeriesTransformer(self.tax_rate_obj, self.leverage_obj)
+
+    def execute(self) -> pd.DataFrame:
+        analyzer = PredictionReturnAnalyzer(
+            self.predicted_returns,
+            self.actual_returns,
+            self.transformer,
+            self.manager,
+        )
+        return analyzer.run_analysis()

--- a/project/modules/performance/metrics/__init__.py
+++ b/project/modules/performance/metrics/__init__.py
@@ -1,0 +1,29 @@
+from .evaluation_metric import (
+    EvaluationMetric,
+    AggregateMetric,
+    SeriesMetric,
+    RankMetric,
+)
+from .expected_return import ExpectedReturn
+from .standard_deviation_of_return import StandardDeviationOfReturn
+from .sharpe_ratio import SharpeRatio
+from .max_drawdown import MaxDrawdown
+from .theoretical_max_drawdown import TheoreticalMaxDrawdown
+from .spearman_correlation import SpearmanCorrelation
+from .numerai_correlation import NumeraiCorrelation
+from .evaluation_metrics_manager import EvaluationMetricsManager
+
+__all__ = [
+    "EvaluationMetric",
+    "AggregateMetric",
+    "SeriesMetric",
+    "RankMetric",
+    "ExpectedReturn",
+    "StandardDeviationOfReturn",
+    "SharpeRatio",
+    "MaxDrawdown",
+    "TheoreticalMaxDrawdown",
+    "SpearmanCorrelation",
+    "NumeraiCorrelation",
+    "EvaluationMetricsManager",
+]

--- a/project/modules/performance/metrics/evaluation_metric.py
+++ b/project/modules/performance/metrics/evaluation_metric.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import pandas as pd
+
+
+class EvaluationMetric(ABC):
+    """評価指標計算クラスの共通基底クラス"""
+
+    def __init__(self, metric_name: str) -> None:
+        self._metric_name = metric_name
+
+    @abstractmethod
+    def calculate(self, returns: pd.Series, **kwargs):
+        """指標値を計算する"""
+        pass
+
+    def get_name(self) -> str:
+        return self._metric_name
+
+
+class AggregateMetric(EvaluationMetric):
+    """時系列全体を集計し単一値を返す指標の基底クラス"""
+
+    def __init__(self, metric_name: str) -> None:
+        super().__init__(metric_name)
+
+
+class SeriesMetric(EvaluationMetric):
+    """時系列形式の値を返す指標の基底クラス"""
+
+    def __init__(self, metric_name: str) -> None:
+        super().__init__(metric_name)
+
+
+class RankMetric(EvaluationMetric):
+    """順位比較を行う指標の基底クラス"""
+
+    def __init__(self, metric_name: str) -> None:
+        super().__init__(metric_name)

--- a/project/modules/performance/metrics/evaluation_metrics_manager.py
+++ b/project/modules/performance/metrics/evaluation_metrics_manager.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from .evaluation_metric import EvaluationMetric
+from .theoretical_max_drawdown import TheoreticalMaxDrawdown
+
+
+class EvaluationMetricsManager:
+    """複数の指標を一括管理するマネージャ"""
+
+    def __init__(self, annualizer: 'Annualizer') -> None:
+        self.annualizer = annualizer
+        self.metrics: list[EvaluationMetric] = []
+
+    def add_metric(self, metric_instance: EvaluationMetric) -> None:
+        self.metrics.append(metric_instance)
+
+    def evaluate_all(self, returns: pd.Series, **kwargs) -> Dict[str, float]:
+        results: Dict[str, float] = {}
+        extra = {}
+        for metric in self.metrics:
+            if isinstance(metric, TheoreticalMaxDrawdown):
+                # 期待リターンと標準偏差を渡す
+                extra = {
+                    "expected_return": returns.mean(),
+                    "std_return": returns.std(ddof=0),
+                }
+            value = metric.calculate(returns, **extra)
+            results[metric.get_name()] = value
+        return results

--- a/project/modules/performance/metrics/expected_return.py
+++ b/project/modules/performance/metrics/expected_return.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .evaluation_metric import AggregateMetric
+
+
+class ExpectedReturn(AggregateMetric):
+    """期待リターン（平均）を計算"""
+
+    def __init__(self) -> None:
+        super().__init__("期待リターン")
+
+    def calculate(self, returns: pd.Series, **kwargs) -> float:
+        return returns.mean()

--- a/project/modules/performance/metrics/max_drawdown.py
+++ b/project/modules/performance/metrics/max_drawdown.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .evaluation_metric import AggregateMetric
+
+
+class MaxDrawdown(AggregateMetric):
+    """最大ドローダウン（実績）を計算"""
+
+    def __init__(self) -> None:
+        super().__init__("最大ドローダウン")
+
+    def calculate(self, returns: pd.Series, **kwargs) -> float:
+        cumulative = (1 + returns).cumprod()
+        dd = 1 - cumulative / cumulative.cummax()
+        return dd.max()

--- a/project/modules/performance/metrics/numerai_correlation.py
+++ b/project/modules/performance/metrics/numerai_correlation.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+
+from .evaluation_metric import RankMetric
+
+
+class NumeraiCorrelation(RankMetric):
+    """Numerai相関を計算するクラス。"""
+
+    def __init__(self) -> None:
+        super().__init__("Numerai相関")
+
+    def _calc_daily_numerai_corr(self, target_rank: pd.Series, pred_rank: pd.Series) -> float:
+        """1日分の Numerai 相関を計算する。"""
+        pred_rank = np.array(pred_rank)
+        scaled_pred = (pred_rank - 0.5) / len(pred_rank)
+        gauss_pred = norm.ppf(scaled_pred)
+        pred_p15 = np.sign(gauss_pred) * np.abs(gauss_pred) ** 1.5
+
+        target_rank = np.array(target_rank)
+        centered_target = target_rank - target_rank.mean()
+        target_p15 = np.sign(centered_target) * np.abs(centered_target) ** 1.5
+
+        return float(np.corrcoef(pred_p15, target_p15)[0, 1])
+
+    def _calc_daily_numerai_rank_corr(self, target_rank: pd.Series, pred_rank: pd.Series) -> float:
+        """Targetをランク化した Numerai 相関を計算する。"""
+        processed = []
+        for arr in (target_rank, pred_rank):
+            arr = np.array(arr)
+            scaled = (arr - 0.5) / len(arr)
+            gauss = norm.ppf(scaled)
+            p15 = np.sign(gauss) * np.abs(gauss) ** 1.5
+            processed.append(p15)
+        return float(np.corrcoef(processed[0], processed[1])[0, 1])
+
+    def calculate(self, series1: pd.Series, **kwargs) -> pd.DataFrame:
+        """予測順位と実際順位から Numerai 相関を計算し統計量を返す。"""
+        series2: pd.Series = kwargs.get("series2")
+        if series2 is None:
+            raise ValueError("series2 が必要です")
+
+        df = pd.concat([series1, series2], axis=1, keys=["pred", "actual"]).dropna()
+
+        if isinstance(df.index, pd.MultiIndex) and "Date" in df.index.names:
+            df["pred_rank"] = df.groupby("Date")["pred"].rank()
+            df["actual_rank"] = df.groupby("Date")["actual"].rank()
+            daily_corr = df.groupby("Date").apply(
+                lambda x: self._calc_daily_numerai_corr(x["actual_rank"], x["pred_rank"])
+            )
+            daily_rank_corr = df.groupby("Date").apply(
+                lambda x: self._calc_daily_numerai_rank_corr(x["actual_rank"], x["pred_rank"])
+            )
+            result = pd.concat([daily_corr, daily_rank_corr], axis=1)
+            result.columns = ["NumeraiCorr", "Rank_NumeraiCorr"]
+            return result.describe().T
+
+        pred_rank = series1.rank()
+        actual_rank = series2.rank()
+        corr = self._calc_daily_numerai_corr(actual_rank, pred_rank)
+        rank_corr = self._calc_daily_numerai_rank_corr(actual_rank, pred_rank)
+        df_out = pd.DataFrame({
+            "NumeraiCorr": [corr],
+            "Rank_NumeraiCorr": [rank_corr],
+        })
+        return df_out.describe().T
+
+    def get_name(self) -> str:
+        return "NumeraiCorrelation"

--- a/project/modules/performance/metrics/sharpe_ratio.py
+++ b/project/modules/performance/metrics/sharpe_ratio.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .evaluation_metric import AggregateMetric
+
+
+class SharpeRatio(AggregateMetric):
+    """シャープレシオを計算"""
+
+    def __init__(self) -> None:
+        super().__init__("シャープレシオ")
+
+    def calculate(self, returns: pd.Series, **kwargs) -> float:
+        mean = returns.mean()
+        std = returns.std(ddof=0)
+        if std == 0:
+            return float("nan")
+        return mean / std

--- a/project/modules/performance/metrics/spearman_correlation.py
+++ b/project/modules/performance/metrics/spearman_correlation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pandas as pd
+from scipy.stats import spearmanr
+
+from .evaluation_metric import RankMetric
+
+
+class SpearmanCorrelation(RankMetric):
+    """Spearman順位相関を計算するクラス。"""
+
+    def __init__(self) -> None:
+        super().__init__("スピアマン順位相関")
+
+    def calculate(self, series1: pd.Series, **kwargs) -> pd.DataFrame:
+        """予測と実績の順位相関を日次で計算し統計量を返す。"""
+        series2: pd.Series = kwargs.get("series2")
+        if series2 is None:
+            raise ValueError("series2 が必要です")
+
+        df = pd.concat([series1, series2], axis=1, keys=["pred", "actual"]).dropna()
+
+        if isinstance(df.index, pd.MultiIndex) and "Date" in df.index.names:
+            df["pred_rank"] = df.groupby("Date")["pred"].rank()
+            df["actual_rank"] = df.groupby("Date")["actual"].rank()
+            daily_corr = df.groupby("Date").apply(
+                lambda x: spearmanr(x["pred_rank"], x["actual_rank"])[0]
+            )
+            return daily_corr.to_frame("SpearmanCorr").describe().T
+
+        corr, _ = spearmanr(df["pred"], df["actual"])
+        return pd.DataFrame({"SpearmanCorr": [corr]}).describe().T

--- a/project/modules/performance/metrics/standard_deviation_of_return.py
+++ b/project/modules/performance/metrics/standard_deviation_of_return.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .evaluation_metric import AggregateMetric
+
+
+class StandardDeviationOfReturn(AggregateMetric):
+    """標準偏差を計算"""
+
+    def __init__(self) -> None:
+        super().__init__("標準偏差")
+
+    def calculate(self, returns: pd.Series, **kwargs) -> float:
+        return returns.std(ddof=0)

--- a/project/modules/performance/metrics/theoretical_max_drawdown.py
+++ b/project/modules/performance/metrics/theoretical_max_drawdown.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .evaluation_metric import AggregateMetric
+
+
+class TheoreticalMaxDrawdown(AggregateMetric):
+    """理論上の最大ドローダウンを計算"""
+
+    def __init__(self) -> None:
+        super().__init__("理論上最大ドローダウン")
+
+    def calculate(self, returns: pd.Series, **kwargs) -> float:
+        mean = kwargs.get("expected_return")
+        std = kwargs.get("std_return")
+        if mean is None:
+            mean = returns.mean()
+        if std is None:
+            std = returns.std(ddof=0)
+        if mean == 0:
+            return float("nan")
+        return (std ** 2) / mean * 9 / 4

--- a/project/modules/performance/transformations.py
+++ b/project/modules/performance/transformations.py
@@ -1,0 +1,39 @@
+"""税率・レバレッジ計算用クラス群"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+class TaxRate:
+    """税金の計算と適用を管理する。"""
+
+    def __init__(self, tax_rate: float = 0.20315) -> None:
+        self.tax_rate = tax_rate
+
+    def apply_tax(self, returns: pd.Series) -> pd.Series:
+        """税引後リターンを計算する。"""
+        taxed = returns.copy()
+        taxed[taxed > 0] = taxed[taxed > 0] * (1 - self.tax_rate)
+        return taxed
+
+    def remove_tax(self, returns: pd.Series) -> pd.Series:
+        """税引後リターンから税引前リターンを推定する。"""
+        untaxed = returns.copy()
+        untaxed[untaxed > 0] = untaxed[untaxed > 0] / (1 - self.tax_rate)
+        return untaxed
+
+
+class Leverage:
+    """レバレッジの適用と解除を管理する。"""
+
+    def __init__(self, leverage_ratio: float = 3.1) -> None:
+        self.leverage_ratio = leverage_ratio
+
+    def apply_leverage(self, returns: pd.Series) -> pd.Series:
+        """レバレッジ適用後リターンを計算する。"""
+        return returns * self.leverage_ratio
+
+    def remove_leverage(self, leveraged_returns: pd.Series) -> pd.Series:
+        """レバレッジ除去後のリターンを計算する。"""
+        return leveraged_returns / self.leverage_ratio


### PR DESCRIPTION
## Summary
- set metric names in Japanese through EvaluationMetric base class
- keep metrics consistent with new `_metric_name` handling

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685ab477028c833288415e2428b9a97f