### PR TITLE
Implement DatasetLoader.pred_result

### DIFF
--- a/class_specs/models/machine_learning/loaders/README.md
+++ b/class_specs/models/machine_learning/loaders/README.md
@@ -7,4 +7,5 @@
 - __init__: 
 - create_grouped_datasets: グループ単位で ``SingleMLDataset`` を作成し ``MLDatasets`` として保存する。
 - load_datasets: 保存済み ``SingleMLDataset`` 群から ``MLDatasets`` を復元する.
+- load_pred_results: dataset_root内の全モデルの ``pred_result_df`` を読み込み結合して返す.
 


### PR DESCRIPTION
## Summary
- add a new utility `load_pred_results` to DatasetLoader to load only `pred_result_df` files
- document the new loader method

## Testing
- `pytest -q` *(fails: pyenv version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b8b937cf48332933132a8afe38889