### PR TITLE
Implement raw target loading

### DIFF
--- a/class_specs/models/machine_learning/loaders/README.md
+++ b/class_specs/models/machine_learning/loaders/README.md
@@ -7,4 +7,6 @@
 - __init__: 
 - create_grouped_datasets: グループ単位で ``SingleMLDataset`` を作成し ``MLDatasets`` として保存する。
 - load_datasets: 保存済み ``SingleMLDataset`` 群から ``MLDatasets`` を復元する.
+- load_pred_results: dataset_root内の全モデルの ``pred_result_df`` を読み込み結合して返す.
+- load_raw_targets: dataset_root内の全モデルの ``raw_target_df`` を読み込み結合して返す.
 

--- a/project/modules/models/machine_learning/loaders/loader.py
+++ b/project/modules/models/machine_learning/loaders/loader.py
@@ -75,6 +75,45 @@ class DatasetLoader:
                 ml_datasets.append_model(SingleMLDataset(path, name))
         return ml_datasets
 
+    def _load_post_processing_dfs(self, filename: str, data_name: str) -> pd.DataFrame:
+        """post_processing_data配下の指定ファイルを結合して返す内部ユーティリティ."""
+        if not os.path.isdir(self.dataset_root):
+            raise FileNotFoundError(f"{self.dataset_root} が存在しません")
+
+        results = []
+        for name in sorted(os.listdir(self.dataset_root)):
+            file_path = os.path.join(self.dataset_root, name, "post_processing_data", filename)
+            if os.path.isfile(file_path):
+                try:
+                    df = pd.read_parquet(file_path)
+                    results.append(df)
+                except Exception as e:
+                    print(f"{file_path} の読み込みに失敗しました。: {e}")
+            else:
+                print(f"警告: {file_path} が存在しません。スキップします。")
+
+        if not results:
+            raise ValueError(f"有効な{data_name}データが見つかりませんでした。")
+
+        combined_df = pd.concat(results, axis=0)
+        if 'Date' in combined_df.index.names:
+            combined_df = combined_df.sort_index()
+        return combined_df
+
+    def load_pred_results(self) -> pd.DataFrame:
+        """dataset_root内に保存された全モデルの ``pred_result_df`` を結合して返す."""
+        return self._load_post_processing_dfs(
+            filename="pred_result_df.parquet",
+            data_name="予測結果"
+        )
+
+    def load_raw_targets(self) -> pd.DataFrame:
+        """dataset_root内の全モデルの ``raw_target_df`` を読み込み結合して返す."""
+        return self._load_post_processing_dfs(
+            filename="raw_target_df.parquet",
+            data_name="生の目的変数",
+        )
+
 
 if __name__ == "__main__":
     from utils.paths import Paths


### PR DESCRIPTION
## Summary
- add helper `_load_post_processing_dfs` for DatasetLoader
- implement `load_raw_targets` using the helper
- update docs for new loader method

## Testing
- `pytest -q` *(fails: pyenv version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b8b937cf48332933132a8afe38889