### PR TITLE
Add ReturnDataFrameBuilder and extend ReturnMetricsRunner

### DIFF
--- a/project/modules/performance/tools/__init__.py
+++ b/project/modules/performance/tools/__init__.py
@@ -1,9 +1,11 @@
 from .daily_return_generator import DailyReturnGenerator
 from .return_metrics_runner import ReturnMetricsRunner
 from .metrics_interactive_viewer import MetricsInteractiveViewer
+from .return_df_builder import ReturnDataFrameBuilder
 
 __all__ = [
     "DailyReturnGenerator",
     "ReturnMetricsRunner",
     "MetricsInteractiveViewer",
+    "ReturnDataFrameBuilder",
 ]

--- a/project/modules/performance/tools/return_df_builder.py
+++ b/project/modules/performance/tools/return_df_builder.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+import pandas as pd
+from models.machine_learning.loaders import DatasetLoader
+
+class ReturnDataFrameBuilder:
+    """Datasetからリターン計算用DataFrameを構築するクラス"""
+
+    def __init__(self, dataset_root: str, start_date: datetime, end_date: datetime) -> None:
+        self.dataset_root = dataset_root
+        self.start_date = start_date
+        self.end_date = end_date
+
+    def build(self) -> pd.DataFrame:
+        """予測値と生の目的変数を結合し期間で抽出したDataFrameを返す"""
+        loader = DatasetLoader(dataset_root=self.dataset_root)
+        pred_df = loader.load_pred_results()
+        raw_df = loader.load_raw_targets()
+        df = pd.merge(raw_df, pred_df[["Pred"]], how="right", left_index=True, right_index=True)
+        df = df[(df.index.get_level_values("Date") >= self.start_date) &
+                (df.index.get_level_values("Date") <= self.end_date)]
+        return df

--- a/project/modules/performance/tools/return_metrics_runner.py
+++ b/project/modules/performance/tools/return_metrics_runner.py
@@ -32,6 +32,8 @@ class ReturnMetricsRunner:
         return_series: pd.Series,
         sector_series: Optional[pd.Series] = None,
         correction_label_series: Optional[pd.Series] = None,
+        trade_sector_numbers: int = 1,
+        top_slope: float = 1.0,
         is_tax_excluded: bool = True,
         is_leverage_applied: bool = False,
         tax_rate: float = 0.20315,
@@ -41,12 +43,50 @@ class ReturnMetricsRunner:
         self.return_series = return_series
         self.label_series = correction_label_series
         self.sector_series = sector_series
+        self.trade_sector_numbers = trade_sector_numbers
+        self.top_slope = top_slope
         self.is_tax_excluded = is_tax_excluded
         self.is_leverage_applied = is_leverage_applied
         self.tax_rate_obj = TaxRate(tax_rate)
         self.leverage_obj = Leverage(leverage_ratio)
         self._setup_aggregate_metrics_manager()
         self._setup_series_metrics_manager()
+
+    def _generate_corrected_returns(self) -> Optional[pd.Series]:
+        """correction_label_series が与えられている場合に LS リターンを計算する"""
+        if self.label_series is None or self.sector_series is None:
+            return None
+
+        df = pd.DataFrame({
+            "Date": self.date_series,
+            "Target": self.return_series,
+            "Pred": self.label_series,
+            "Sector": self.sector_series,
+        }).dropna()
+
+        df["TargetRank"] = df.groupby("Date")["Target"].rank(ascending=False)
+        df["PredRank"] = df.groupby("Date")["Pred"].rank(ascending=False)
+
+        sector_numbers = df["Sector"].nunique()
+        long_df = df[df["PredRank"] <= self.trade_sector_numbers]
+        short_df = df[df["PredRank"] > sector_numbers - self.trade_sector_numbers]
+
+        if self.trade_sector_numbers > 1:
+            long_df.loc[long_df["PredRank"] == 1, "Target"] *= self.top_slope
+            long_df.loc[long_df["PredRank"] != 1, "Target"] *= 1 - (self.top_slope - 1) / (
+                self.trade_sector_numbers - 1
+            )
+            short_df.loc[short_df["PredRank"] == sector_numbers, "Target"] *= self.top_slope
+            short_df.loc[short_df["PredRank"] != sector_numbers, "Target"] *= 1 - (
+                self.top_slope - 1
+            ) / (self.trade_sector_numbers - 1)
+
+        long_return = long_df.groupby("Date")[["Target"]].mean()
+        short_return = -short_df.groupby("Date")[["Target"]].mean()
+        ls_return = (long_return + short_return) / 2
+        ls_return = ls_return["Target"]
+
+        return ls_return
 
     def _setup_aggregate_metrics_manager(self) -> None:
         self.aggregate_metrics_manager = EvaluationMetricsManager(Annualizer())
@@ -74,7 +114,15 @@ class ReturnMetricsRunner:
 
     def calculate(self) -> Dict[str, Dict[str, pd.DataFrame]]:
         """3パターンのリターンに対する指標を階層的な辞書で返す"""
-        base = self._get_base_returns()
+        corrected = self._generate_corrected_returns()
+        if corrected is not None:
+            base = corrected.copy()
+            if self.is_leverage_applied:
+                base = self.leverage_obj.remove_leverage(base)
+            if not self.is_tax_excluded:
+                base = self.tax_rate_obj.remove_tax(base)
+        else:
+            base = self._get_base_returns()
 
         patterns = {
             "税引前・レバレッジ無": base,


### PR DESCRIPTION
## Summary
- add new `ReturnDataFrameBuilder` to easily create evaluation DataFrames
- export builder from performance tools package
- update `ReturnMetricsRunner` to compute long-short returns when labels are provided

## Testing
- `python3 -m py_compile project/modules/performance/tools/return_df_builder.py project/modules/performance/tools/return_metrics_runner.py project/modules/performance/tools/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685bab456f4083328f6416fbc68930be