### PR TITLE
ReturnMetricsRunner を実績リターン評価用に整理

### DIFF
--- a/project/modules/performance/tools/return_metrics_runner.py
+++ b/project/modules/performance/tools/return_metrics_runner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Dict, Union
+from typing import Dict
 import pandas as pd
 
 from .. import (
@@ -11,7 +11,6 @@ from .. import (
     MaxDrawdown,
     TheoreticalMaxDrawdown,
     EvaluationMetricsManager,
-    SpearmanCorrelation,
     Median,
     DailyReturn,
     MonthlyReturn,
@@ -20,7 +19,6 @@ from .. import (
     Leverage,
 )
 
-from .daily_return_generator import DailyReturnGenerator
 
 
 class ReturnMetricsRunner:
@@ -30,10 +28,6 @@ class ReturnMetricsRunner:
         self,
         date_series: pd.Series,
         return_series: pd.Series,
-        sector_series: Optional[pd.Series] = None,
-        correction_label_series: Optional[pd.Series] = None,
-        trade_sector_numbers: int = 1,
-        top_slope: float = 1.0,
         is_tax_excluded: bool = True,
         is_leverage_applied: bool = False,
         tax_rate: float = 0.20315,
@@ -41,52 +35,12 @@ class ReturnMetricsRunner:
     ) -> None:
         self.date_series = date_series
         self.return_series = return_series
-        self.label_series = correction_label_series
-        self.sector_series = sector_series
-        self.trade_sector_numbers = trade_sector_numbers
-        self.top_slope = top_slope
         self.is_tax_excluded = is_tax_excluded
         self.is_leverage_applied = is_leverage_applied
         self.tax_rate_obj = TaxRate(tax_rate)
         self.leverage_obj = Leverage(leverage_ratio)
         self._setup_aggregate_metrics_manager()
         self._setup_series_metrics_manager()
-
-    def _generate_corrected_returns(self) -> Optional[pd.Series]:
-        """correction_label_series が与えられている場合に LS リターンを計算する"""
-        if self.label_series is None or self.sector_series is None:
-            return None
-
-        df = pd.DataFrame({
-            "Date": self.date_series,
-            "Target": self.return_series,
-            "Pred": self.label_series,
-            "Sector": self.sector_series,
-        }).dropna()
-
-        df["TargetRank"] = df.groupby("Date")["Target"].rank(ascending=False)
-        df["PredRank"] = df.groupby("Date")["Pred"].rank(ascending=False)
-
-        sector_numbers = df["Sector"].nunique()
-        long_df = df[df["PredRank"] <= self.trade_sector_numbers]
-        short_df = df[df["PredRank"] > sector_numbers - self.trade_sector_numbers]
-
-        if self.trade_sector_numbers > 1:
-            long_df.loc[long_df["PredRank"] == 1, "Target"] *= self.top_slope
-            long_df.loc[long_df["PredRank"] != 1, "Target"] *= 1 - (self.top_slope - 1) / (
-                self.trade_sector_numbers - 1
-            )
-            short_df.loc[short_df["PredRank"] == sector_numbers, "Target"] *= self.top_slope
-            short_df.loc[short_df["PredRank"] != sector_numbers, "Target"] *= 1 - (
-                self.top_slope - 1
-            ) / (self.trade_sector_numbers - 1)
-
-        long_return = long_df.groupby("Date")[["Target"]].mean()
-        short_return = -short_df.groupby("Date")[["Target"]].mean()
-        ls_return = (long_return + short_return) / 2
-        ls_return = ls_return["Target"]
-
-        return ls_return
 
     def _setup_aggregate_metrics_manager(self) -> None:
         self.aggregate_metrics_manager = EvaluationMetricsManager(Annualizer())
@@ -114,15 +68,7 @@ class ReturnMetricsRunner:
 
     def calculate(self) -> Dict[str, Dict[str, pd.DataFrame]]:
         """3パターンのリターンに対する指標を階層的な辞書で返す"""
-        corrected = self._generate_corrected_returns()
-        if corrected is not None:
-            base = corrected.copy()
-            if self.is_leverage_applied:
-                base = self.leverage_obj.remove_leverage(base)
-            if not self.is_tax_excluded:
-                base = self.tax_rate_obj.remove_tax(base)
-        else:
-            base = self._get_base_returns()
+        base = self._get_base_returns()
 
         patterns = {
             "税引前・レバレッジ無": base,


### PR DESCRIPTION
## Summary
- ReturnMetricsRunnerから予測評価関連の処理を削除
- 不要な引数を無くし、実績リターン評価に専念

## Testing
- `pytest -q` *(fails: pyenv can't find required Python version)*

------
https://chatgpt.com/codex/tasks/task_e_685baff1c9508332ba060552e41871cf