### PR TITLE
Refactor metric classes to store results internally

### DIFF
--- a/project/modules/performance/analyzers.py
+++ b/project/modules/performance/analyzers.py
@@ -57,7 +57,8 @@ class PredictionReturnAnalyzer:
             result = self.manager.evaluate_all(transformed)
             # 相関は別途計算し平均値を格納
             corr_metric = SpearmanCorrelation()
-            corr_df = corr_metric.calculate(transformed, series2=self.actual)
+            corr_metric.calculate(transformed, series2=self.actual)
+            corr_df = corr_metric.value
             corr_mean = float("nan")
             if "SpearmanCorr" in corr_df.index:
                 corr_mean = corr_df.loc["SpearmanCorr", "mean"]

--- a/project/modules/performance/metrics/aggregate/annualized_return.py
+++ b/project/modules/performance/metrics/aggregate/annualized_return.py
@@ -13,7 +13,6 @@ class AnnualizedReturn(AggregateMetric):
         super().__init__("年率リターン")
         self.annualizer = Annualizer(trading_days_per_year)
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         mean_daily = returns.mean()
-        self.value = self.annualizer.annualize_return(mean_daily)
-        return self.value
+        self._value = self.annualizer.annualize_return(mean_daily)

--- a/project/modules/performance/metrics/aggregate/annualized_sharpe_ratio.py
+++ b/project/modules/performance/metrics/aggregate/annualized_sharpe_ratio.py
@@ -13,13 +13,12 @@ class AnnualizedSharpeRatio(AggregateMetric):
         super().__init__("年率シャープレシオ")
         self.annualizer = Annualizer(trading_days_per_year)
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         mean_daily = returns.mean()
         std_daily = returns.std(ddof=0)
         if std_daily == 0:
-            self.value = float("nan")
+            self._value = float("nan")
         else:
             ann_ret = self.annualizer.annualize_return(mean_daily)
             ann_std = self.annualizer.annualize_volatility(std_daily)
-            self.value = ann_ret / ann_std
-        return self.value
+            self._value = ann_ret / ann_std

--- a/project/modules/performance/metrics/aggregate/annualized_standard_deviation.py
+++ b/project/modules/performance/metrics/aggregate/annualized_standard_deviation.py
@@ -13,7 +13,6 @@ class AnnualizedStandardDeviation(AggregateMetric):
         super().__init__("年率標準偏差")
         self.annualizer = Annualizer(trading_days_per_year)
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         std = returns.std(ddof=0)
-        self.value = self.annualizer.annualize_volatility(std)
-        return self.value
+        self._value = self.annualizer.annualize_volatility(std)

--- a/project/modules/performance/metrics/aggregate/calmar_ratio.py
+++ b/project/modules/performance/metrics/aggregate/calmar_ratio.py
@@ -13,13 +13,12 @@ class CalmarRatio(AggregateMetric):
         super().__init__("カルマーレシオ")
         self.annualizer = Annualizer(trading_days_per_year)
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         ann_ret = self.annualizer.annualize_return(returns.mean())
         cumulative = (1 + returns).cumprod()
         dd = 1 - cumulative / cumulative.cummax()
         mdd = dd.max()
         if mdd == 0:
-            self.value = float("nan")
+            self._value = float("nan")
         else:
-            self.value = ann_ret / mdd
-        return self.value
+            self._value = ann_ret / mdd

--- a/project/modules/performance/metrics/aggregate/expected_return.py
+++ b/project/modules/performance/metrics/aggregate/expected_return.py
@@ -11,6 +11,5 @@ class ExpectedReturn(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("期待リターン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
-        self.value = returns.mean()
-        return self.value
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
+        self._value = returns.mean()

--- a/project/modules/performance/metrics/aggregate/hit_rate.py
+++ b/project/modules/performance/metrics/aggregate/hit_rate.py
@@ -11,6 +11,5 @@ class HitRate(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("勝率")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
-        self.value = float((returns > 0).mean())
-        return self.value
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
+        self._value = float((returns > 0).mean())

--- a/project/modules/performance/metrics/aggregate/longest_drawdown_period.py
+++ b/project/modules/performance/metrics/aggregate/longest_drawdown_period.py
@@ -11,7 +11,7 @@ class LongestDrawdownPeriod(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("最長ドローダウン期間")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         cumulative = (1 + returns).cumprod()
         peaks = cumulative.cummax()
         drawdown = cumulative < peaks
@@ -24,5 +24,4 @@ class LongestDrawdownPeriod(AggregateMetric):
                 longest = max(longest, current)
                 current = 0
         longest = max(longest, current)
-        self.value = float(longest)
-        return self.value
+        self._value = float(longest)

--- a/project/modules/performance/metrics/aggregate/max_drawdown.py
+++ b/project/modules/performance/metrics/aggregate/max_drawdown.py
@@ -11,8 +11,7 @@ class MaxDrawdown(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("最大ドローダウン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         cumulative = (1 + returns).cumprod()
         dd = 1 - cumulative / cumulative.cummax()
-        self.value = dd.max()
-        return self.value
+        self._value = dd.max()

--- a/project/modules/performance/metrics/aggregate/median.py
+++ b/project/modules/performance/metrics/aggregate/median.py
@@ -11,6 +11,5 @@ class Median(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("中央値")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
-        self.value = returns.median()
-        return self.value
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
+        self._value = returns.median()

--- a/project/modules/performance/metrics/aggregate/sharpe_ratio.py
+++ b/project/modules/performance/metrics/aggregate/sharpe_ratio.py
@@ -11,11 +11,10 @@ class SharpeRatio(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("シャープレシオ")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         mean = returns.mean()
         std = returns.std(ddof=0)
         if std == 0:
-            self.value = float("nan")
+            self._value = float("nan")
         else:
-            self.value = mean / std
-        return self.value
+            self._value = mean / std

--- a/project/modules/performance/metrics/aggregate/standard_deviation_of_return.py
+++ b/project/modules/performance/metrics/aggregate/standard_deviation_of_return.py
@@ -11,6 +11,5 @@ class StandardDeviationOfReturn(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("標準偏差")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
-        self.value = returns.std(ddof=0)
-        return self.value
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
+        self._value = returns.std(ddof=0)

--- a/project/modules/performance/metrics/aggregate/theoretical_max_drawdown.py
+++ b/project/modules/performance/metrics/aggregate/theoretical_max_drawdown.py
@@ -11,7 +11,7 @@ class TheoreticalMaxDrawdown(AggregateMetric):
     def __init__(self) -> None:
         super().__init__("理論上最大ドローダウン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> float:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         mean = kwargs.get("expected_return")
         std = kwargs.get("std_return")
         if mean is None:
@@ -19,7 +19,6 @@ class TheoreticalMaxDrawdown(AggregateMetric):
         if std is None:
             std = returns.std(ddof=0)
         if mean == 0:
-            self.value = float("nan")
+            self._value = float("nan")
         else:
-            self.value = (std ** 2) / mean * 9 / 4
-        return self.value
+            self._value = (std ** 2) / mean * 9 / 4

--- a/project/modules/performance/metrics/evaluation_metric.py
+++ b/project/modules/performance/metrics/evaluation_metric.py
@@ -1,40 +1,50 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Generic, Optional, TypeVar
+
 import pandas as pd
 
+T = TypeVar("T")
 
-class EvaluationMetric(ABC):
+
+class EvaluationMetric(ABC, Generic[T]):
     """評価指標計算クラスの共通基底クラス"""
 
     def __init__(self, metric_name: str) -> None:
         self._metric_name = metric_name
-        self.value = None
+        self._value: Optional[T] = None
 
     @abstractmethod
-    def calculate(self, returns: pd.Series, **kwargs):
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         """指標値を計算する"""
         pass
+
+    @property
+    def value(self) -> T:
+        if self._value is None:
+            raise ValueError("Metric value has not been calculated yet")
+        return self._value
 
     def get_name(self) -> str:
         return self._metric_name
 
 
-class AggregateMetric(EvaluationMetric):
+class AggregateMetric(EvaluationMetric[float]):
     """時系列全体を集計し単一値を返す指標の基底クラス"""
 
     def __init__(self, metric_name: str) -> None:
         super().__init__(metric_name)
 
 
-class SeriesMetric(EvaluationMetric):
+class SeriesMetric(EvaluationMetric[pd.DataFrame]):
     """時系列形式の値を返す指標の基底クラス"""
 
     def __init__(self, metric_name: str) -> None:
         super().__init__(metric_name)
 
 
-class RankMetric(EvaluationMetric):
+class RankMetric(EvaluationMetric[pd.DataFrame]):
     """順位比較を行う指標の基底クラス"""
 
     def __init__(self, metric_name: str) -> None:

--- a/project/modules/performance/metrics/evaluation_metrics_manager.py
+++ b/project/modules/performance/metrics/evaluation_metrics_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict
 
 import pandas as pd
 
@@ -18,8 +18,8 @@ class EvaluationMetricsManager:
     def add_metric(self, metric_instance: EvaluationMetric) -> None:
         self.metrics.append(metric_instance)
 
-    def evaluate_all(self, returns: pd.Series, **kwargs) -> Dict[str, float]:
-        results: Dict[str, float] = {}
+    def evaluate_all(self, returns: pd.Series, **kwargs) -> Dict[str, Any]:
+        results: Dict[str, Any] = {}
         extra = {}
         for metric in self.metrics:
             if isinstance(metric, TheoreticalMaxDrawdown):
@@ -28,6 +28,6 @@ class EvaluationMetricsManager:
                     "expected_return": returns.mean(),
                     "std_return": returns.std(ddof=0),
                 }
-            value = metric.calculate(returns, **extra)
-            results[metric.get_name()] = value
+            metric.calculate(returns, **extra)
+            results[metric.get_name()] = metric.value
         return results

--- a/project/modules/performance/metrics/rank/numerai_correlation.py
+++ b/project/modules/performance/metrics/rank/numerai_correlation.py
@@ -37,7 +37,7 @@ class NumeraiCorrelation(RankMetric):
             processed.append(p15)
         return float(np.corrcoef(processed[0], processed[1])[0, 1])
 
-    def calculate(self, series1: pd.Series, **kwargs) -> pd.DataFrame:
+    def calculate(self, series1: pd.Series, **kwargs) -> None:
         """予測順位と実際順位から Numerai 相関を計算し統計量を返す。"""
         series2: pd.Series = kwargs.get("series2")
         if series2 is None:
@@ -56,8 +56,8 @@ class NumeraiCorrelation(RankMetric):
             )
             result = pd.concat([daily_corr, daily_rank_corr], axis=1)
             result.columns = ["NumeraiCorr", "Rank_NumeraiCorr"]
-            self.value = result.describe().T
-            return self.value
+            self._value = result.describe().T
+            return
 
         pred_rank = series1.rank()
         actual_rank = series2.rank()
@@ -67,8 +67,7 @@ class NumeraiCorrelation(RankMetric):
             "NumeraiCorr": [corr],
             "Rank_NumeraiCorr": [rank_corr],
         })
-        self.value = df_out.describe().T
-        return self.value
+        self._value = df_out.describe().T
 
     def get_name(self) -> str:
         return "NumeraiCorrelation"

--- a/project/modules/performance/metrics/rank/spearman_correlation.py
+++ b/project/modules/performance/metrics/rank/spearman_correlation.py
@@ -12,7 +12,7 @@ class SpearmanCorrelation(RankMetric):
     def __init__(self) -> None:
         super().__init__("スピアマン順位相関")
 
-    def calculate(self, series1: pd.Series, **kwargs) -> pd.DataFrame:
+    def calculate(self, series1: pd.Series, **kwargs) -> None:
         """予測と実績の順位相関を日次で計算し統計量を返す。"""
         series2: pd.Series = kwargs.get("series2")
         if series2 is None:
@@ -26,9 +26,8 @@ class SpearmanCorrelation(RankMetric):
             daily_corr = df.groupby("Date").apply(
                 lambda x: spearmanr(x["pred_rank"], x["actual_rank"])[0]
             )
-            self.value = daily_corr.to_frame("SpearmanCorr").describe().T
-            return self.value
+            self._value = daily_corr.to_frame("SpearmanCorr").describe().T
+            return
 
         corr, _ = spearmanr(df["pred"], df["actual"])
-        self.value = pd.DataFrame({"SpearmanCorr": [corr]}).describe().T
-        return self.value
+        self._value = pd.DataFrame({"SpearmanCorr": [corr]}).describe().T

--- a/project/modules/performance/metrics/series/annual_return.py
+++ b/project/modules/performance/metrics/series/annual_return.py
@@ -11,9 +11,8 @@ class AnnualReturn(SeriesMetric):
     def __init__(self) -> None:
         super().__init__("年次リターン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> pd.DataFrame:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         annual = (1 + returns).resample("YE").prod() - 1
         df = annual.to_frame("AnnualReturn")
         df.index.name = "Date"
-        self.value = df
-        return self.value
+        self._value = df

--- a/project/modules/performance/metrics/series/cumulative_return.py
+++ b/project/modules/performance/metrics/series/cumulative_return.py
@@ -11,9 +11,8 @@ class CumulativeReturn(SeriesMetric):
     def __init__(self) -> None:
         super().__init__("累積リターン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> pd.DataFrame:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         cumulative = (1 + returns).cumprod() - 1
         df = cumulative.to_frame("CumulativeReturn")
         df.index.name = returns.index.name or "Date"
-        self.value = df
-        return self.value
+        self._value = df

--- a/project/modules/performance/metrics/series/daily_return.py
+++ b/project/modules/performance/metrics/series/daily_return.py
@@ -11,8 +11,7 @@ class DailyReturn(SeriesMetric):
     def __init__(self) -> None:
         super().__init__("日次リターン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> pd.DataFrame:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         df = returns.to_frame("DailyReturn")
         df.index.name = returns.index.name or "Date"
-        self.value = df
-        return self.value
+        self._value = df

--- a/project/modules/performance/metrics/series/monthly_return.py
+++ b/project/modules/performance/metrics/series/monthly_return.py
@@ -11,9 +11,8 @@ class MonthlyReturn(SeriesMetric):
     def __init__(self) -> None:
         super().__init__("月次リターン")
 
-    def calculate(self, returns: pd.Series, **kwargs) -> pd.DataFrame:
+    def calculate(self, returns: pd.Series, **kwargs) -> None:
         monthly = (1 + returns).resample("ME").prod() - 1
         df = monthly.to_frame("MonthlyReturn")
         df.index.name = "Date"
-        self.value = df
-        return self.value
+        self._value = df


### PR DESCRIPTION
## Summary
- refactor `EvaluationMetric` with generics and a read-only `value` property
- update metric subclasses to store results internally
- change `EvaluationMetricsManager` and `PredictionReturnAnalyzer` to use the new API

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bdd98a770833283470f2f8e863533