### PR TITLE
Fix repeated title in metrics viewer

### DIFF
--- a/project/modules/performance/tools/metrics_interactive_viewer.py
+++ b/project/modules/performance/tools/metrics_interactive_viewer.py
@@ -37,8 +37,7 @@ class MetricsInteractiveViewer:
                 data = self.metrics[group][metric]
                 with pd.option_context("display.max_rows", None):
                     if isinstance(data, pd.DataFrame):
-                        print(f"{group}：{metric}")
-                        display(data)
+                        display(data.style.set_caption(f"{group}：{metric}"))
                     else:
                         print(f"{group}：{metric}: {data}")
 


### PR DESCRIPTION
## Summary
- fix duplicate title line in `MetricsInteractiveViewer`

## Testing
- `pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685d32f308488332945a8bc6c3182874