### PR TITLE
Rename EvaluationMetricsManager to MetricsCollection

### DIFF
--- a/project/modules/performance/__init__.py
+++ b/project/modules/performance/__init__.py
@@ -20,7 +20,7 @@ from .metrics import (
     LongestDrawdownPeriod,
     AnnualizedSharpeRatio,
     CalmarRatio,
-    EvaluationMetricsManager,
+    MetricsCollection,
     Median,
     DailyReturn,
     MonthlyReturn,

--- a/project/modules/performance/analyzers.py
+++ b/project/modules/performance/analyzers.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from .transformations import TaxRate, Leverage
 from .annualizer import Annualizer
-from .metrics import EvaluationMetricsManager, SpearmanCorrelation
+from .metrics import MetricsCollection, SpearmanCorrelation
 
 
 @dataclass
@@ -38,7 +38,7 @@ class PredictionReturnAnalyzer:
     """予測リターンと実際のリターンを評価するクラス"""
 
     def __init__(self, raw_predicted_returns: pd.Series, actual_returns: pd.Series,
-                 transformer: ReturnSeriesTransformer, evaluation_manager: EvaluationMetricsManager) -> None:
+                 transformer: ReturnSeriesTransformer, evaluation_manager: MetricsCollection) -> None:
         if not raw_predicted_returns.index.equals(actual_returns.index):
             raise ValueError("インデックスが一致していません")
         self.raw_predicted = raw_predicted_returns
@@ -71,7 +71,7 @@ class TradeResultAnalyzer:
     """実際の取引結果を評価するクラス"""
 
     def __init__(self, raw_trade_df: pd.DataFrame, transformer: ReturnSeriesTransformer,
-                 evaluation_manager: EvaluationMetricsManager) -> None:
+                 evaluation_manager: MetricsCollection) -> None:
         if not {"Date", "Symbol", "DailyReturn"}.issubset(raw_trade_df.columns):
             raise ValueError("必要なカラムが存在しません")
         self.raw_trade_df = raw_trade_df.copy()

--- a/project/modules/performance/executor.py
+++ b/project/modules/performance/executor.py
@@ -10,7 +10,7 @@ from .metrics import (
     SharpeRatio,
     MaxDrawdown,
     TheoreticalMaxDrawdown,
-    EvaluationMetricsManager,
+    MetricsCollection,
 )
 from .analyzers import ReturnSeriesTransformer, PredictionReturnAnalyzer
 
@@ -33,7 +33,7 @@ class PredictionReturnExecutor:
         self.tax_rate_obj = TaxRate(tax_rate)
         self.leverage_obj = Leverage(leverage_ratio)
         self.annualizer = Annualizer(trading_days_per_year)
-        self.manager = EvaluationMetricsManager(self.annualizer)
+        self.manager = MetricsCollection(self.annualizer)
         self.manager.add_metric(ExpectedReturn())
         self.manager.add_metric(StandardDeviationOfReturn())
         self.manager.add_metric(SharpeRatio())

--- a/project/modules/performance/metrics/__init__.py
+++ b/project/modules/performance/metrics/__init__.py
@@ -26,7 +26,7 @@ from .aggregate.annualized_standard_deviation import AnnualizedStandardDeviation
 from .aggregate.longest_drawdown_period import LongestDrawdownPeriod
 from .aggregate.annualized_sharpe_ratio import AnnualizedSharpeRatio
 from .aggregate.calmar_ratio import CalmarRatio
-from .evaluation_metrics_manager import EvaluationMetricsManager
+from .metrics_collection import MetricsCollection
 
 __all__ = [
     "EvaluationMetric",
@@ -53,5 +53,5 @@ __all__ = [
     "LongestDrawdownPeriod",
     "AnnualizedSharpeRatio",
     "CalmarRatio",
-    "EvaluationMetricsManager",
+    "MetricsCollection",
 ]

--- a/project/modules/performance/metrics/metrics_collection.py
+++ b/project/modules/performance/metrics/metrics_collection.py
@@ -9,7 +9,7 @@ from .aggregate.theoretical_max_drawdown import TheoreticalMaxDrawdown
 from ..annualizer import Annualizer
 
 
-class EvaluationMetricsManager:
+class MetricsCollection:
     """複数の指標を一括管理するマネージャ"""
 
     def __init__(self, annualizer: 'Annualizer') -> None:

--- a/project/modules/performance/tools/return_metrics_runner.py
+++ b/project/modules/performance/tools/return_metrics_runner.py
@@ -19,7 +19,7 @@ from .. import (
     LongestDrawdownPeriod,
     AnnualizedSharpeRatio,
     CalmarRatio,
-    EvaluationMetricsManager,
+    MetricsCollection,
     Median,
     DailyReturn,
     MonthlyReturn,
@@ -51,7 +51,7 @@ class ReturnMetricsRunner:
         self._setup_series_metrics_manager()
 
     def _setup_aggregate_metrics_manager(self) -> None:
-        self.aggregate_metrics_manager = EvaluationMetricsManager(Annualizer())
+        self.aggregate_metrics_manager = MetricsCollection(Annualizer())
         self.aggregate_metrics_manager.add_metric(ExpectedReturn())
         self.aggregate_metrics_manager.add_metric(StandardDeviationOfReturn())
         self.aggregate_metrics_manager.add_metric(Median())
@@ -66,7 +66,7 @@ class ReturnMetricsRunner:
         self.aggregate_metrics_manager.add_metric(CalmarRatio())
 
     def _setup_series_metrics_manager(self) -> None:
-        self.series_metrics_manager = EvaluationMetricsManager(Annualizer())
+        self.series_metrics_manager = MetricsCollection(Annualizer())
         self.series_metrics_manager.add_metric(DailyReturn())
         self.series_metrics_manager.add_metric(MonthlyReturn())
         self.series_metrics_manager.add_metric(AnnualReturn())


### PR DESCRIPTION
## Summary
- クラス名 `EvaluationMetricsManager` を `MetricsCollection` に変更
- ファイル名を `metrics_collection.py` に変更し、それに伴うインポートや型注釈を更新

## Testing
- `pytest -q` *(失敗: pyenv 未設定のため)*

------
https://chatgpt.com/codex/tasks/task_e_685d346d41f483329d0eec433faf6cd3