### PR TITLE
Move tax and leverage classes to submodule

### DIFF
--- a/project/modules/performance/__init__.py
+++ b/project/modules/performance/__init__.py
@@ -1,4 +1,4 @@
-from .transformations import TaxRate, Leverage
+from .transformation import TaxRate, Leverage
 from .annualizer import Annualizer
 from .metrics import (
     EvaluationMetric,

--- a/project/modules/performance/analyzers.py
+++ b/project/modules/performance/analyzers.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import pandas as pd
 
-from .transformations import TaxRate, Leverage
+from .transformation import TaxRate, Leverage
 from .annualizer import Annualizer
 from .metrics import MetricsCollection, SpearmanCorrelation
 

--- a/project/modules/performance/executor.py
+++ b/project/modules/performance/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from .transformations import TaxRate, Leverage
+from .transformation import TaxRate, Leverage
 from .annualizer import Annualizer
 from .metrics import (
     ExpectedReturn,

--- a/project/modules/performance/transformation/__init__.py
+++ b/project/modules/performance/transformation/__init__.py
@@ -1,0 +1,7 @@
+from .tax_rate import TaxRate
+from .leverage import Leverage
+
+__all__ = [
+    "TaxRate",
+    "Leverage",
+]

--- a/project/modules/performance/transformation/leverage.py
+++ b/project/modules/performance/transformation/leverage.py
@@ -1,0 +1,20 @@
+"""レバレッジ計算を扱うモジュール"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+class Leverage:
+    """レバレッジの適用と解除を管理する。"""
+
+    def __init__(self, leverage_ratio: float = 3.1) -> None:
+        self.leverage_ratio = leverage_ratio
+
+    def apply_leverage(self, returns: pd.Series) -> pd.Series:
+        """レバレッジ適用後リターンを計算する。"""
+        return returns * self.leverage_ratio
+
+    def remove_leverage(self, leveraged_returns: pd.Series) -> pd.Series:
+        """レバレッジ除去後のリターンを計算する。"""
+        return leveraged_returns / self.leverage_ratio

--- a/project/modules/performance/transformation/tax_rate.py
+++ b/project/modules/performance/transformation/tax_rate.py
@@ -1,4 +1,4 @@
-"""税率・レバレッジ計算用クラス群"""
+"""税金の計算と適用を管理するモジュール"""
 
 from __future__ import annotations
 
@@ -22,18 +22,3 @@ class TaxRate:
         untaxed = returns.copy()
         untaxed = untaxed / (1 - self.tax_rate)
         return untaxed
-
-
-class Leverage:
-    """レバレッジの適用と解除を管理する。"""
-
-    def __init__(self, leverage_ratio: float = 3.1) -> None:
-        self.leverage_ratio = leverage_ratio
-
-    def apply_leverage(self, returns: pd.Series) -> pd.Series:
-        """レバレッジ適用後リターンを計算する。"""
-        return returns * self.leverage_ratio
-
-    def remove_leverage(self, leveraged_returns: pd.Series) -> pd.Series:
-        """レバレッジ除去後のリターンを計算する。"""
-        return leveraged_returns / self.leverage_ratio


### PR DESCRIPTION
## Summary
- separate `TaxRate` and `Leverage` from `transformations.py`
- place them under new `transformation` package
- update imports

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d408bf4f08332bbefd5da4b0aa36c