### PR TITLE
Update ML facades to refresh data during prediction

### DIFF
--- a/project/execution_scripts/current_files/PO_54Lasso_48Ensemble.py
+++ b/project/execution_scripts/current_files/PO_54Lasso_48Ensemble.py
@@ -65,6 +65,13 @@ async def main() -> None:
         ml_54_lasso = LassoLearningFacade(
             mode=modes.machine_learning_mode,
             dataset_path=datasets_54_lasso,
+            stock_dfs_dict=stock_dict,
+            sector_redef_csv_path=sector_csv_54_lasso,
+            sector_index_parquet_path=sector_index_parquet,
+            train_start_day=train_start_day,
+            train_end_day=train_end_day,
+            test_start_day=test_start_day,
+            test_end_day=test_end_day,
         ).execute()
 
         ml_48_ensemble = MachineLearningFacade(

--- a/project/modules/facades/data_pipeline/lasso_learning_facade.py
+++ b/project/modules/facades/data_pipeline/lasso_learning_facade.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Dict, Literal
+import pandas as pd
+from datetime import datetime
 import os
 
 from models.machine_learning.loaders.loader import DatasetLoader
 from models.machine_learning.models.lasso_model import LassoModel
 from models.machine_learning.ml_dataset.ml_datasets import MLDatasets
+from calculation import SectorIndex, TargetCalculator, FeaturesCalculator
 from utils.notifier import SlackNotifier
 
 
@@ -16,11 +19,87 @@ class LassoLearningFacade:
         self,
         mode: Literal["train_and_predict", "predict_only", "load_only", "none"],
         dataset_path: str,
+        stock_dfs_dict: Dict[str, pd.DataFrame] | None = None,
+        sector_redef_csv_path: str | None = None,
+        sector_index_parquet_path: str | None = None,
+        train_start_day: datetime | None = None,
+        train_end_day: datetime | None = None,
+        test_start_day: datetime | None = None,
+        test_end_day: datetime | None = None,
     ) -> None:
         self.mode = mode
         self.dataset_path = dataset_path
+        self.stock_dfs_dict = stock_dfs_dict
+        self.sector_redef_csv_path = sector_redef_csv_path
+        self.sector_index_parquet_path = sector_index_parquet_path
+        self.train_start_day = train_start_day
+        self.train_end_day = train_end_day
+        self.test_start_day = test_start_day
+        self.test_end_day = test_end_day
         # Slack通知用
         self.slack = SlackNotifier(program_name=os.path.basename(__file__))
+        self.target_df: pd.DataFrame | None = None
+        self.raw_target_df: pd.DataFrame | None = None
+        self.order_price_df: pd.DataFrame | None = None
+        self.new_sector_price_df: pd.DataFrame | None = None
+        self.features_df: pd.DataFrame | None = None
+
+    def _get_necessary_dfs(self) -> None:
+        if self.stock_dfs_dict is None:
+            return
+        sic = SectorIndex(
+            self.stock_dfs_dict,
+            self.sector_redef_csv_path,
+            self.sector_index_parquet_path,
+        )
+        new_sector_price_df, order_price_df = sic.calc_sector_index()
+        raw_target_df, target_df = TargetCalculator.daytime_return_PCAresiduals(
+            new_sector_price_df,
+            reduce_components=1,
+            train_start_day=self.train_start_day,
+            train_end_day=self.train_end_day,
+        )
+        self.target_df = target_df
+        self.raw_target_df = raw_target_df
+        self.order_price_df = order_price_df
+        self.new_sector_price_df = new_sector_price_df
+
+    def _get_features_df(self) -> pd.DataFrame:
+        return FeaturesCalculator.calculate_features(
+            new_sector_price=self.new_sector_price_df,
+            new_sector_list=pd.read_csv(self.sector_redef_csv_path),
+            stock_dfs_dict=self.stock_dfs_dict,
+            adopts_features_indices=True,
+            adopts_features_price=False,
+            groups_setting=None,
+            names_setting=None,
+            currencies_type="relative",
+            adopt_1d_return=True,
+            adopt_size_factor=False,
+            adopt_eps_factor=False,
+            adopt_sector_categorical=False,
+            add_rank=False,
+        )
+
+    def _refresh_test_data(self, ml_datasets: MLDatasets) -> None:
+        if self.target_df is None or self.features_df is None:
+            return
+        for name, single_ml in ml_datasets.items():
+            target_single = self.target_df.xs(name, level="Sector")
+            features_single = self.features_df.xs(name, level="Sector")
+            single_ml.archive_train_test_data(
+                target_df=target_single,
+                features_df=features_single,
+                train_start_day=self.train_start_day,
+                train_end_day=self.train_end_day,
+                test_start_day=self.test_start_day,
+                test_end_day=self.test_end_day,
+                outlier_threshold=3,
+            )
+            single_ml.archive_raw_target(self.raw_target_df)
+            single_ml.archive_order_price(self.order_price_df)
+            single_ml.save()
+            ml_datasets.replace_model(single_ml_dataset=single_ml)
 
     def execute(self) -> MLDatasets | None:
         if self.mode == "none":
@@ -28,6 +107,11 @@ class LassoLearningFacade:
 
         loader = DatasetLoader(self.dataset_path)
         ml_datasets = loader.load_datasets()
+
+        if self.mode in ("train_and_predict", "predict_only"):
+            self._get_necessary_dfs()
+            self.features_df = self._get_features_df()
+            self._refresh_test_data(ml_datasets)
 
         if self.mode == "train_and_predict":
             self._train(ml_datasets)

--- a/project/modules/facades/data_pipeline/machine_learning_facade.py
+++ b/project/modules/facades/data_pipeline/machine_learning_facade.py
@@ -59,9 +59,39 @@ class MachineLearningFacade:
             self._update_ensembled_model()
             result = self.ensembled_ml_datasets
         elif self.mode == 'predict_only':
+            self.features_df1 = self._get_features_df(
+                adopt_features_price=False,
+                adopt_size_factor=False,
+                adopt_eps_factor=False,
+                adopt_sector_categorical=False,
+                add_rank=False,
+            )
             self.ml_datasets1 = self._load_model(dataset_root=self.datasets1_path)
+            self._refresh_test_data(
+                self.ml_datasets1,
+                self.features_df1,
+                outlier_threshold=3,
+            )
             self._predict_1st_model()
+
+            self.features_df2 = self._get_features_df(
+                adopt_features_price=True,
+                adopt_size_factor=True,
+                adopt_eps_factor=True,
+                adopt_sector_categorical=True,
+                add_rank=True,
+                mom_duration=[5, 21],
+                vola_duration=[5, 21],
+            )
+            self._append_pred_in_1st_model()
             self.ml_datasets2 = self._load_model(dataset_root=self.datasets2_path)
+            self._refresh_test_data(
+                self.ml_datasets2,
+                self.features_df2,
+                outlier_threshold=3,
+                no_shift_features=['1stModel_pred'],
+                reuse_features_df=True,
+            )
             self._predict_2nd_model()
             self._ensemble()
             self._update_ensembled_model()
@@ -97,6 +127,37 @@ class MachineLearningFacade:
     def _load_model(self, dataset_root: str) -> MLDatasets:
         dsl = DatasetLoader(dataset_root = dataset_root)
         return dsl.load_datasets()
+
+    def _refresh_test_data(
+        self,
+        ml_datasets: MLDatasets,
+        features_df: pd.DataFrame,
+        *,
+        outlier_threshold: float = 0,
+        no_shift_features: list | None = None,
+        reuse_features_df: bool = False,
+    ) -> None:
+        if no_shift_features is None:
+            no_shift_features = []
+
+        for name, single_ml in ml_datasets.items():
+            target_single = self.target_df.xs(name, level="Sector")
+            features_single = features_df.xs(name, level="Sector")
+            single_ml.archive_train_test_data(
+                target_df=target_single,
+                features_df=features_single,
+                train_start_day=self.train_start_day,
+                train_end_day=self.train_end_day,
+                test_start_day=self.test_start_day,
+                test_end_day=self.test_end_day,
+                outlier_threshold=outlier_threshold,
+                no_shift_features=no_shift_features,
+                reuse_features_df=reuse_features_df,
+            )
+            single_ml.archive_raw_target(self.raw_target_df)
+            single_ml.archive_order_price(self.order_price_df)
+            single_ml.save()
+            ml_datasets.replace_model(single_ml_dataset=single_ml)
 
 
     def _train_1st_model(self):


### PR DESCRIPTION
## Summary
- refresh existing ML datasets with latest target and feature data before prediction
- update Lasso facade to support dataset refresh when predicting
- adjust execution script to pass new parameters

## Testing
- `python3 -m py_compile project/modules/facades/data_pipeline/machine_learning_facade.py project/modules/facades/data_pipeline/lasso_learning_facade.py project/execution_scripts/current_files/PO_54Lasso_48Ensemble.py`
- `pytest -q` *(fails: pyenv not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e1631d6b88332bc9abc2da6ddd5ed