### PR TITLE
Add ML core framework with data bundle and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# ML Core Quick Start
+
+このパッケージは、データ・モデル・メタ情報をひとかたまりとして管理する仕組みを提供します。
+
+```python
+from pathlib import Path
+from ml_core.data_bundle import DataBundle
+from ml_core.unified_mlobject import UnifiedMLObject
+from ml_core.ml_package import MLPackage
+
+# DataFrame は MultiIndex(['Date', 'Sector']) を想定
+bundle = DataBundle(features_df, targets_df, order_price_df)
+ml = UnifiedMLObject()
+package = MLPackage(ml, bundle)
+package.train()
+pred_df = package.predict()
+package.save(Path('saved_model'))
+
+loaded = MLPackage.load(Path('saved_model'))
+loaded.predict()
+```
+
+```mermaid
+classDiagram
+    class DataBundle
+    class BaseMLObject
+    class UnifiedMLObject
+    class MultiMLObject
+    class MLPackage
+    class MLRegistry
+
+    DataBundle <.. MLPackage
+    BaseMLObject <|.. UnifiedMLObject
+    BaseMLObject <|.. MultiMLObject
+    MLPackage o-- BaseMLObject
+    MLPackage o-- DataBundle
+    MLRegistry --> MLPackage
+```
+

--- a/ml_core/base_mlobject.py
+++ b/ml_core/base_mlobject.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import pandas as pd
+
+
+class BaseMLObject(Protocol):
+    """Protocol that all machine learning objects must follow."""
+
+    def fit(self, data: 'DataBundle') -> None:
+        """Fit the model using the provided data."""
+
+    def predict(self, features: pd.DataFrame) -> pd.DataFrame:
+        """Return predictions for the given features."""
+
+    def save(self, path: Path) -> None:
+        """Serialize the ML object to the given path."""
+
+    @classmethod
+    def load(cls, path: Path) -> 'BaseMLObject':
+        """Load the ML object from a file."""
+

--- a/ml_core/data_bundle.py
+++ b/ml_core/data_bundle.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+import json
+import pandas as pd
+
+
+@dataclass
+class DataBundle:
+    """Container for feature and target data with optional preprocessing."""
+
+    features: pd.DataFrame
+    targets: pd.DataFrame
+    order_price: Optional[pd.DataFrame] = None
+    meta: Dict | None = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.features = self.features.copy()
+        self.targets = self.targets.copy()
+        if self.order_price is not None:
+            self.order_price = self.order_price.copy()
+        if self.meta is None:
+            self.meta = {}
+
+    def prepare(self) -> None:
+        """Run simple preprocessing like outlier removal."""
+        threshold = self.meta.get("outlier_threshold")
+        if threshold is not None:
+            mask = (self.features.abs() > threshold)
+            self.features[mask] = pd.NA
+            self.features.dropna(inplace=True)
+            self.targets = self.targets.loc[self.features.index]
+            if self.order_price is not None:
+                self.order_price = self.order_price.loc[self.features.index]
+
+    def slice_date(self, date: pd.Timestamp) -> "DataBundle":
+        """Return a new DataBundle filtered by date."""
+        features = self.features.xs(date, level="Date", drop_level=False)
+        targets = self.targets.xs(date, level="Date", drop_level=False)
+        op = None
+        if self.order_price is not None:
+            op = self.order_price.xs(date, level="Date", drop_level=False)
+        return DataBundle(features, targets, op, self.meta)
+
+    def save(self, dir_: Path) -> None:
+        """Save bundle contents to a directory."""
+        dir_.mkdir(parents=True, exist_ok=True)
+        self.features.to_parquet(dir_ / "features.parquet")
+        self.targets.to_parquet(dir_ / "targets.parquet")
+        if self.order_price is not None:
+            self.order_price.to_parquet(dir_ / "order_price.parquet")
+        with open(dir_ / "meta.json", "w", encoding="utf-8") as f:
+            json.dump(self.meta, f)
+
+    @classmethod
+    def load(cls, dir_: Path) -> "DataBundle":
+        """Load bundle contents from a directory."""
+        features = pd.read_parquet(dir_ / "features.parquet")
+        targets = pd.read_parquet(dir_ / "targets.parquet")
+        op_path = dir_ / "order_price.parquet"
+        op = pd.read_parquet(op_path) if op_path.exists() else None
+        meta_path = dir_ / "meta.json"
+        if meta_path.exists():
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+        else:
+            meta = {}
+        return cls(features=features, targets=targets, order_price=op, meta=meta)
+

--- a/ml_core/ml_package.py
+++ b/ml_core/ml_package.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+
+from .base_mlobject import BaseMLObject
+from .data_bundle import DataBundle
+
+
+@dataclass
+class MLPackage:
+    """Bundle of ML object, data and meta information."""
+
+    ml_object: BaseMLObject
+    data: DataBundle
+    meta: dict = field(default_factory=dict)
+
+    def train(self) -> None:
+        """Train internal ML object."""
+        self.data.prepare()
+        self.ml_object.fit(self.data)
+
+    def predict(self, features: pd.DataFrame | None = None) -> pd.DataFrame:
+        """Predict using the ML object."""
+        feats = features if features is not None else self.data.features
+        return self.ml_object.predict(feats)
+
+    def save(self, dir_: Path) -> None:
+        """Save package components to disk."""
+        dir_.mkdir(parents=True, exist_ok=True)
+        self.ml_object.save(dir_ / "ml_object.pkl")
+        self.data.save(dir_ / "data")
+        with open(dir_ / "meta.json", "w", encoding="utf-8") as f:
+            json.dump(self.meta, f)
+
+    @classmethod
+    def load(cls, dir_: Path) -> "MLPackage":
+        """Load package from disk."""
+        ml_object = UnifiedMLObject.load(dir_ / "ml_object.pkl")
+        data = DataBundle.load(dir_ / "data")
+        meta_path = dir_ / "meta.json"
+        if meta_path.exists():
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+        else:
+            meta = {}
+        return cls(ml_object=ml_object, data=data, meta=meta)
+
+
+from .unified_mlobject import UnifiedMLObject  # after class definition
+import pandas as pd
+

--- a/ml_core/ml_registry.py
+++ b/ml_core/ml_registry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from .ml_package import MLPackage
+
+
+class MLRegistry:
+    """Registry for storing ML packages identified by keys."""
+
+    def __init__(self, root_dir: Path) -> None:
+        self.root_dir = root_dir
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+        self.packages: Dict[str, MLPackage] = {}
+
+    def save(self, key: str, obj: MLPackage) -> None:
+        dir_ = self.root_dir / key
+        obj.save(dir_)
+        self.packages[key] = obj
+
+    def load(self, key: str) -> MLPackage:
+        dir_ = self.root_dir / key
+        pkg = MLPackage.load(dir_)
+        self.packages[key] = pkg
+        return pkg
+

--- a/ml_core/multi_mlobject.py
+++ b/ml_core/multi_mlobject.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pickle
+from typing import Dict, Optional
+
+import pandas as pd
+from sklearn.linear_model import Lasso
+from sklearn.preprocessing import StandardScaler
+
+from .base_mlobject import BaseMLObject
+from .data_bundle import DataBundle
+
+
+class MultiMLObject(BaseMLObject):
+    """Sector-wise models with corresponding scalers."""
+
+    def __init__(self) -> None:
+        self.models: Dict[str, Lasso] = {}
+        self.scalers: Dict[str, StandardScaler] = {}
+
+    def fit(self, data: DataBundle) -> None:
+        for sector in data.features.index.get_level_values("Sector").unique():
+            X = data.features.xs(sector, level="Sector")
+            y = data.targets.xs(sector, level="Sector").squeeze()
+            scaler = StandardScaler()
+            X_scaled = pd.DataFrame(scaler.fit_transform(X), index=X.index, columns=X.columns)
+            model = Lasso()
+            model.fit(X_scaled, y)
+            self.models[sector] = model
+            self.scalers[sector] = scaler
+
+    def predict(self, features: pd.DataFrame) -> pd.DataFrame:
+        results = []
+        for sector in features.index.get_level_values("Sector").unique():
+            X = features.xs(sector, level="Sector")
+            scaler = self.scalers.get(sector)
+            model = self.models.get(sector)
+            if scaler is None or model is None:
+                continue
+            X_scaled = pd.DataFrame(scaler.transform(X), index=X.index, columns=X.columns)
+            preds = model.predict(X_scaled)
+            df = pd.DataFrame(preds, index=X.index, columns=["Pred"])
+            results.append(df)
+        return pd.concat(results).sort_index()
+
+    def save(self, path: Path) -> None:
+        with open(path, "wb") as f:
+            pickle.dump({"models": self.models, "scalers": self.scalers}, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "MultiMLObject":
+        with open(path, "rb") as f:
+            obj = pickle.load(f)
+        instance = cls()
+        instance.models = obj.get("models", {})
+        instance.scalers = obj.get("scalers", {})
+        return instance
+

--- a/ml_core/unified_mlobject.py
+++ b/ml_core/unified_mlobject.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pickle
+from typing import Optional
+
+import pandas as pd
+from lightgbm import LGBMRegressor
+from sklearn.preprocessing import StandardScaler
+
+from .base_mlobject import BaseMLObject
+from .data_bundle import DataBundle
+
+
+class UnifiedMLObject(BaseMLObject):
+    """Single model approach with optional scaler."""
+
+    def __init__(self, model: Optional[LGBMRegressor] = None, scaler: Optional[StandardScaler] = None) -> None:
+        self.model = model or LGBMRegressor()
+        self.scaler = scaler
+
+    def fit(self, data: DataBundle) -> None:
+        X = data.features
+        y = data.targets.squeeze()
+        if self.scaler is not None:
+            X = pd.DataFrame(self.scaler.fit_transform(X), index=X.index, columns=X.columns)
+        self.model.fit(X, y)
+
+    def predict(self, features: pd.DataFrame) -> pd.DataFrame:
+        X = features
+        if self.scaler is not None:
+            X = pd.DataFrame(self.scaler.transform(X), index=X.index, columns=X.columns)
+        preds = self.model.predict(X)
+        return pd.DataFrame(preds, index=features.index, columns=["Pred"])
+
+    def save(self, path: Path) -> None:
+        with open(path, "wb") as f:
+            pickle.dump({"model": self.model, "scaler": self.scaler}, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "UnifiedMLObject":
+        with open(path, "rb") as f:
+            obj = pickle.load(f)
+        return cls(model=obj.get("model"), scaler=obj.get("scaler"))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+scikit-learn
+lightgbm
+pyarrow

--- a/tests/test_train_predict.py
+++ b/tests/test_train_predict.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import numpy as np
+from pathlib import Path
+import tempfile
+
+from ml_core.data_bundle import DataBundle
+from ml_core.unified_mlobject import UnifiedMLObject
+from ml_core.multi_mlobject import MultiMLObject
+from ml_core.ml_package import MLPackage
+
+
+def _make_dummy_bundle() -> DataBundle:
+    dates = pd.date_range("2020-01-01", periods=4, freq="D")
+    sectors = ["A", "B"]
+    index = pd.MultiIndex.from_product([dates, sectors], names=["Date", "Sector"])
+    features = pd.DataFrame({"f1": np.random.randn(len(index)), "f2": np.random.randn(len(index))}, index=index)
+    targets = pd.DataFrame({"y": np.random.randn(len(index))}, index=index)
+    order_price = pd.DataFrame({"price": np.random.rand(len(index))}, index=index)
+    bundle = DataBundle(features, targets, order_price, {"outlier_threshold": 3.0})
+    return bundle
+
+
+def test_unified_mlobject_cycle():
+    bundle = _make_dummy_bundle()
+    ml = UnifiedMLObject()
+    pkg = MLPackage(ml, bundle)
+    pkg.train()
+    preds = pkg.predict()
+    assert not preds.empty
+    with tempfile.TemporaryDirectory() as d:
+        pkg.save(Path(d))
+        loaded = MLPackage.load(Path(d))
+        preds2 = loaded.predict()
+        assert preds2.shape == preds.shape
+
+
+def test_multi_mlobject_cycle():
+    bundle = _make_dummy_bundle()
+    ml = MultiMLObject()
+    pkg = MLPackage(ml, bundle)
+    pkg.train()
+    preds = pkg.predict()
+    assert not preds.empty
+    with tempfile.TemporaryDirectory() as d:
+        pkg.save(Path(d))
+        loaded = MLPackage.load(Path(d))
+        preds2 = loaded.predict()
+        assert preds2.shape == preds.shape
+


### PR DESCRIPTION
## Summary
- add `ml_core` module with DataBundle, ML objects, and registry
- implement simple train/predict cycle tests
- document quick start usage
- provide `requirements.txt`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685eb18f4f6083328c90b04bf921f029