### PR TITLE
Update Lasso facade

### DIFF
--- a/project/modules/facades/data_pipeline/lasso_learning_facade.py
+++ b/project/modules/facades/data_pipeline/lasso_learning_facade.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from typing import Literal
+import pandas as pd
 import os
+from datetime import datetime
 
 from models.machine_learning.loaders.loader import DatasetLoader
 from models.machine_learning.models.lasso_model import LassoModel
@@ -10,15 +12,29 @@ from utils.notifier import SlackNotifier
 
 
 class LassoLearningFacade:
-    """LASSOモデルの学習・予測を担当するシンプルなファサード"""
+    """LASSOモデルによる学習・予測を担当するファサード"""
 
     def __init__(
         self,
         mode: Literal["train_and_predict", "predict_only", "load_only", "none"],
         dataset_path: str,
+        target_df: pd.DataFrame | None = None,
+        features_df: pd.DataFrame | None = None,
+        train_start_day: datetime | None = None,
+        train_end_day: datetime | None = None,
+        test_start_day: datetime | None = None,
+        test_end_day: datetime | None = None,
     ) -> None:
         self.mode = mode
         self.dataset_path = dataset_path
+        self.target_df = target_df
+        self.features_df = features_df
+        self.train_start_day = train_start_day
+        self.train_end_day = train_end_day
+        self.test_start_day = test_start_day
+        self.test_end_day = test_end_day
+        self.ml_datasets: MLDatasets | None = None
+
         # Slack通知用
         self.slack = SlackNotifier(program_name=os.path.basename(__file__))
 
@@ -27,20 +43,36 @@ class LassoLearningFacade:
             return None
 
         loader = DatasetLoader(self.dataset_path)
-        ml_datasets = loader.load_datasets()
 
         if self.mode == "train_and_predict":
-            self._train(ml_datasets)
-            self._predict(ml_datasets)
+            if self.target_df is not None and self.features_df is not None:
+                self.ml_datasets = loader.create_grouped_datasets(
+                    target_df=self.target_df,
+                    features_df=self.features_df,
+                    train_start_day=self.train_start_day,
+                    train_end_day=self.train_end_day,
+                    test_start_day=self.test_start_day,
+                    test_end_day=self.test_end_day,
+                    raw_target_df=None,
+                    order_price_df=None,
+                    outlier_threshold=3,
+                )
+            else:
+                self.ml_datasets = loader.load_datasets()
+            self._train(self.ml_datasets)
+            self._predict(self.ml_datasets)
         elif self.mode == "predict_only":
-            self._predict(ml_datasets)
+            self.ml_datasets = loader.load_datasets()
+            self._update_test_data(self.ml_datasets)
+            self._predict(self.ml_datasets)
         elif self.mode == "load_only":
-            pass
+            self.ml_datasets = loader.load_datasets()
         else:
             raise NotImplementedError
 
-        self._notify_latest_prediction_date(ml_datasets)
-        return ml_datasets
+        if self.ml_datasets is not None:
+            self._notify_latest_prediction_date(self.ml_datasets)
+        return self.ml_datasets
 
     def _train(self, ml_datasets: MLDatasets) -> None:
         model = LassoModel()
@@ -63,6 +95,22 @@ class LassoLearningFacade:
                 single_ml.ml_object_materials.scaler,
             )
             single_ml.archive_pred_result(pred_df)
+            single_ml.save()
+            ml_datasets.replace_model(single_ml_dataset=single_ml)
+
+    def _update_test_data(self, ml_datasets: MLDatasets) -> None:
+        if self.target_df is None or self.features_df is None:
+            return
+        for name, single_ml in ml_datasets.items():
+            sector_target = self.target_df[self.target_df.index.get_level_values('Sector') == name]
+            sector_features = self.features_df[self.features_df.index.get_level_values('Sector') == name]
+            if self.test_start_day is not None and self.test_end_day is not None:
+                sector_target = sector_target[(sector_target.index.get_level_values('Date') >= self.test_start_day) &
+                                             (sector_target.index.get_level_values('Date') <= self.test_end_day)]
+                sector_features = sector_features[(sector_features.index.get_level_values('Date') >= self.test_start_day) &
+                                                 (sector_features.index.get_level_values('Date') <= self.test_end_day)]
+            single_ml.train_test_data._target_test_df = sector_target
+            single_ml.train_test_data._features_test_df = sector_features
             single_ml.save()
             ml_datasets.replace_model(single_ml_dataset=single_ml)
 


### PR DESCRIPTION
## Summary
- rewrite `LassoLearningFacade` based on the first model implementation of `MachineLearningFacade`
- support rebuilding datasets and updating test data during predictions

## Testing
- `pyenv shell 3.11.12`
- `python -m pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685ecd1734c48332924ff10a72503d61