### PR TITLE
Implement MLDataPipeline for preprocessing

### DIFF
--- a/project/modules/facades/data_pipeline/__init__.py
+++ b/project/modules/facades/data_pipeline/__init__.py
@@ -1,5 +1,6 @@
 from .data_update_facade import DataUpdateFacade
 from .machine_learning_facade import MachineLearningFacade
+from .machine_learning_facade_new import MachineLearningFacadeNew
 from .order_execution_facade import OrderExecutionFacade
 from .model_order_config import ModelOrderConfig, normalize_margin_weights
 from .lasso_learning_facade import LassoLearningFacade
@@ -8,6 +9,7 @@ from .trade_data_facade import TradeDataFacade
 __all__ = [
     'DataUpdateFacade',
     'MachineLearningFacade',
+    'MachineLearningFacadeNew',
     'OrderExecutionFacade',
     'ModelOrderConfig',
     'normalize_margin_weights',

--- a/project/modules/facades/data_pipeline/machine_learning_facade_new.py
+++ b/project/modules/facades/data_pipeline/machine_learning_facade_new.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+import pandas as pd
+
+from calculation import TargetCalculator, FeaturesCalculator, SectorIndex
+from utils.timeseries import Duration
+from machine_learning.ml_dataset.core import PreprocessingConfig, MLDataset
+from machine_learning.ml_dataset.creators import MLDatasetCreator
+from machine_learning.ml_dataset.components import MachineLearningAsset
+from machine_learning.models import BaseTrainer
+
+
+class MachineLearningFacadeNew:
+    """MLDataset と新しい前処理パイプラインを利用した学習ファサード"""
+
+    def __init__(
+        self,
+        stock_dfs_dict: Dict[str, pd.DataFrame],
+        sector_redef_csv_path: str,
+        sector_index_parquet_path: str,
+        dataset_path: str,
+        train_duration: Duration,
+        test_duration: Duration,
+        date_column: str,
+        model_division_column: Optional[str] = None,
+        preprocessing_config: PreprocessingConfig | None = None,
+    ) -> None:
+        self.stock_dfs_dict = stock_dfs_dict
+        self.sector_redef_csv_path = sector_redef_csv_path
+        self.sector_index_parquet_path = sector_index_parquet_path
+        self.dataset_path = dataset_path
+        self.train_duration = train_duration
+        self.test_duration = test_duration
+        self.date_column = date_column
+        self.model_division_column = model_division_column
+        self.preprocessing_config = preprocessing_config or PreprocessingConfig()
+        self.ml_dataset: MLDataset | None = None
+
+        self.target_df: pd.DataFrame | None = None
+        self.raw_target_df: pd.DataFrame | None = None
+        self.features_df: pd.DataFrame | None = None
+        self.order_price_df: pd.DataFrame | None = None
+        self.new_sector_price_df: pd.DataFrame | None = None
+
+    # ------------------------------------------------------------------
+    # データセット作成 / 読み込み
+    # ------------------------------------------------------------------
+    def create_dataset(
+        self,
+        adopt_features_price: bool = True,
+        adopt_size_factor: bool = True,
+        adopt_eps_factor: bool = True,
+        adopt_sector_categorical: bool = True,
+        add_rank: bool = True,
+        mom_duration: Optional[List[int]] = None,
+        vola_duration: Optional[List[int]] = None,
+    ) -> None:
+        """原データからMLDatasetを生成"""
+        self._get_necessary_dfs()
+        self.features_df = self._get_features_df(
+            adopt_features_price=adopt_features_price,
+            adopt_size_factor=adopt_size_factor,
+            adopt_eps_factor=adopt_eps_factor,
+            adopt_sector_categorical=adopt_sector_categorical,
+            add_rank=add_rank,
+            mom_duration=mom_duration,
+            vola_duration=vola_duration,
+        )
+
+        dummy_asset = MachineLearningAsset(name="init", model=None, scaler=None)
+        self.ml_dataset = MLDatasetCreator.create(
+            dataset_path=self.dataset_path,
+            target_df=self.target_df,
+            features_df=self.features_df,
+            raw_returns_df=self.raw_target_df,
+            pred_result_df=pd.DataFrame(),
+            train_duration=self.train_duration,
+            test_duration=self.test_duration,
+            date_column=self.date_column,
+            ml_asset=dummy_asset,
+            model_division_column=self.model_division_column,
+            preprocessing_config=self.preprocessing_config,
+        )
+
+    def load_dataset(self) -> None:
+        """保存済みデータセットを読み込む"""
+        self.ml_dataset = MLDatasetCreator.load(self.dataset_path)
+
+    # ------------------------------------------------------------------
+    # データ生成
+    # ------------------------------------------------------------------
+    def _get_necessary_dfs(self) -> None:
+        """目的変数計算に必要なデータフレームを生成する"""
+        sic = SectorIndex(
+            self.stock_dfs_dict,
+            self.sector_redef_csv_path,
+            self.sector_index_parquet_path,
+        )
+        new_sector_price_df, order_price_df = sic.calc_sector_index()
+        raw_target_df, target_df = TargetCalculator.daytime_return_PCAresiduals(
+            new_sector_price_df,
+            reduce_components=1,
+            train_start_day=self.train_duration.start,
+            train_end_day=self.train_duration.end,
+        )
+        self.target_df = target_df
+        self.raw_target_df = raw_target_df
+        self.order_price_df = order_price_df
+        self.new_sector_price_df = new_sector_price_df
+
+    def _get_features_df(
+        self,
+        adopt_features_price: bool,
+        adopt_size_factor: bool,
+        adopt_eps_factor: bool,
+        adopt_sector_categorical: bool,
+        add_rank: bool,
+        mom_duration: Optional[List[int]] = None,
+        vola_duration: Optional[List[int]] = None,
+    ) -> pd.DataFrame:
+        new_sector_list = pd.read_csv(self.sector_redef_csv_path)
+        return FeaturesCalculator.calculate_features(
+            new_sector_price=self.new_sector_price_df,
+            new_sector_list=new_sector_list,
+            stock_dfs_dict=self.stock_dfs_dict,
+            adopts_features_indices=True,
+            adopts_features_price=adopt_features_price,
+            groups_setting=None,
+            names_setting=None,
+            currencies_type="relative",
+            adopt_1d_return=True,
+            mom_duration=mom_duration,
+            vola_duration=vola_duration,
+            adopt_size_factor=adopt_size_factor,
+            adopt_eps_factor=adopt_eps_factor,
+            adopt_sector_categorical=adopt_sector_categorical,
+            add_rank=add_rank,
+        )
+
+    # ------------------------------------------------------------------
+    # 学習・予測
+    # ------------------------------------------------------------------
+    def train(self, trainer: BaseTrainer, **kwargs) -> None:
+        """データセットを学習"""
+        if self.ml_dataset is None:
+            self.load_dataset()
+        self.ml_dataset.train(trainer, **kwargs)
+        self.ml_dataset._save()
+
+    def predict(self) -> pd.DataFrame:
+        """データセットで予測を実施"""
+        if self.ml_dataset is None:
+            self.load_dataset()
+        self.ml_dataset.predict()
+        self.ml_dataset._save()
+        return self.ml_dataset.pred_result_df

--- a/project/modules/machine_learning/ml_dataset/core/__init__.py
+++ b/project/modules/machine_learning/ml_dataset/core/__init__.py
@@ -1,1 +1,3 @@
 from .ml_dataset import MLDataset, MLDatasetStorage
+from .preprocessing_config import PreprocessingConfig
+from .ml_data_pipeline import MLDataPipeline

--- a/project/modules/machine_learning/ml_dataset/core/ml_data_pipeline.py
+++ b/project/modules/machine_learning/ml_dataset/core/ml_data_pipeline.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import List
+import pandas as pd
+
+from utils.jquants_api_utils import get_next_open_date
+
+from .preprocessing_config import PreprocessingConfig
+
+
+class MLDataPipeline:
+    """MLDataset用の前処理パイプライン"""
+
+    def __init__(self, ml_dataset: 'MLDataset'):
+        self.ml_dataset = ml_dataset
+        self._preprocessing_done = False
+
+    def prepare_for_training(self, config: PreprocessingConfig | None = None):
+        """学習用の前処理を実行"""
+        if self._preprocessing_done:
+            return
+        config = config or self.ml_dataset.preprocessing_config
+        self._prepare_data_structure(config.no_shift_features)
+        if config.outlier_threshold and config.outlier_threshold > 0:
+            self.remove_outliers(config.outlier_threshold)
+        if config.remove_missing_data:
+            self._handle_missing_data()
+        self._align_dataframes()
+        self._preprocessing_done = True
+
+    def prepare_for_prediction(self):
+        """予測用の前処理を実行"""
+        if self._preprocessing_done:
+            return
+        config = self.ml_dataset.preprocessing_config
+        self._prepare_data_structure(config.no_shift_features)
+        if config.remove_missing_data:
+            self._handle_missing_data()
+        self._align_dataframes()
+        self._preprocessing_done = True
+
+    def _prepare_data_structure(self, no_shift_features: List[str]):
+        """翌営業日追加→特徴量シフトを順次実行"""
+        self.ml_dataset.target_df = self._append_next_business_day_row(self.ml_dataset.target_df)
+        self.ml_dataset.features_df = self._append_next_business_day_row(self.ml_dataset.features_df)
+        self.ml_dataset.raw_returns_df = self._append_next_business_day_row(self.ml_dataset.raw_returns_df)
+
+        shift_features = [c for c in self.ml_dataset.features_df.columns if c not in no_shift_features]
+        if shift_features:
+            self.ml_dataset.features_df[shift_features] = (
+                self.ml_dataset.features_df.groupby('Sector')[shift_features].shift(1)
+            )
+
+    def remove_outliers(self, threshold: float):
+        """外れ値除去（セクター別、統計的手法）"""
+        target_df = self.ml_dataset.target_df
+        filtered = target_df.groupby('Sector').apply(
+            self._filter_outliers_by_group, column_name='Target', coef=threshold
+        ).droplevel(0)
+        filtered = filtered.sort_index()
+        self.ml_dataset.target_df = filtered
+        self.ml_dataset.features_df = self.ml_dataset.features_df.loc[self.ml_dataset.features_df.index.isin(filtered.index)]
+        self.ml_dataset.raw_returns_df = self.ml_dataset.raw_returns_df.loc[self.ml_dataset.raw_returns_df.index.isin(filtered.index)]
+
+    def _align_dataframes(self):
+        """3つのDataFrameのインデックスを揃える"""
+        idx = self.ml_dataset.target_df.index
+        idx = idx.intersection(self.ml_dataset.features_df.index)
+        idx = idx.intersection(self.ml_dataset.raw_returns_df.index)
+        self.ml_dataset.target_df = self.ml_dataset.target_df.loc[idx]
+        self.ml_dataset.features_df = self.ml_dataset.features_df.loc[idx]
+        self.ml_dataset.raw_returns_df = self.ml_dataset.raw_returns_df.loc[idx]
+
+    def _handle_missing_data(self):
+        """欠損値の処理"""
+        merged = pd.concat(
+            [self.ml_dataset.target_df, self.ml_dataset.features_df, self.ml_dataset.raw_returns_df],
+            axis=1,
+            join='inner'
+        ).dropna()
+        t_cols = self.ml_dataset.target_df.columns
+        f_cols = self.ml_dataset.features_df.columns
+        r_cols = self.ml_dataset.raw_returns_df.columns
+        self.ml_dataset.target_df = merged[t_cols]
+        self.ml_dataset.features_df = merged[f_cols]
+        self.ml_dataset.raw_returns_df = merged[r_cols]
+
+    @staticmethod
+    def _filter_outliers_by_group(group: pd.DataFrame, column_name: str, coef: float = 3) -> pd.DataFrame:
+        mean = group[column_name].mean()
+        std = group[column_name].std()
+        lower_bound = mean - coef * std
+        upper_bound = mean + coef * std
+        return group[(group[column_name] >= lower_bound) & (group[column_name] <= upper_bound)]
+
+    @staticmethod
+    def _append_next_business_day_row(df: pd.DataFrame) -> pd.DataFrame:
+        next_open_date = get_next_open_date(latest_date=df.index.get_level_values('Date')[-1])
+        sectors = df.index.get_level_values('Sector').unique()
+        new_rows = [[next_open_date for _ in range(len(sectors))], [s for s in sectors]]
+        data_to_add = pd.DataFrame(index=new_rows, columns=df.columns).dropna(axis=1, how='all')
+        data_to_add.index.names = ['Date', 'Sector']
+        df = pd.concat([df, data_to_add], axis=0).reset_index(drop=False)
+        df['Date'] = pd.to_datetime(df['Date'])
+        return df.set_index(['Date', 'Sector'], drop=True)

--- a/project/modules/machine_learning/ml_dataset/core/ml_dataset.py
+++ b/project/modules/machine_learning/ml_dataset/core/ml_dataset.py
@@ -7,6 +7,8 @@ import os # ファイル存在チェック用
 from utils.timeseries import Duration
 from machine_learning.ml_dataset.components import MachineLearningAsset
 from machine_learning.models import BaseTrainer
+from .ml_data_pipeline import MLDataPipeline
+from .preprocessing_config import PreprocessingConfig
 
 @dataclass
 class MLDataset:
@@ -24,6 +26,13 @@ class MLDataset:
     model_division_column: Optional[str] = None #モデルを分割する場合、どの列の値をキーに分割するか？
 
     ml_assets: Union[MachineLearningAsset, List[MachineLearningAsset]] = field(default_factory=list)
+    preprocessing_config: PreprocessingConfig | None = None
+    data_pipeline: MLDataPipeline = field(init=False)
+
+    def __post_init__(self):
+        if self.preprocessing_config is None:
+            self.preprocessing_config = PreprocessingConfig()
+        self.data_pipeline = MLDataPipeline(self)
 
     def update_dataframes(self, new_target_data: pd.DataFrame, new_features_data: pd.DataFrame, new_raw_returns_data: pd.DataFrame):
         """
@@ -37,6 +46,10 @@ class MLDataset:
         # ここで更新されたDataFrameをファイルに保存するロジックを追加することも可能
         # 例: self.target_df.to_parquet("path/to/updated_target.parquet")
 
+    def apply_preprocessing(self, config: PreprocessingConfig | None = None):
+        """手動で前処理を実行"""
+        self.data_pipeline.prepare_for_training(config)
+
     def train(self, trainer: BaseTrainer, **kwargs):
         """
         学習期間のデータを使用してモデルを学習させます。
@@ -45,6 +58,9 @@ class MLDataset:
         Args:
             trainer (BaseTrainer): 任意の機械学習トレーナークラス
         """
+        # 前処理を自動実行
+        self.data_pipeline.prepare_for_training()
+
         if self.model_division_column not in self.target_df.columns:
             raise ValueError(f"モデル分割列 '{self.model_division_column}' が学習データに存在しません。")
         
@@ -93,6 +109,9 @@ class MLDataset:
         model_load_pathが指定されていれば、そこからモデルをロードします。
         予測結果はpred_result_dfに格納され、pred_result_save_pathが指定されていればファイルに保存されます。
         """
+        # 予測前の前処理を実行
+        self.data_pipeline.prepare_for_prediction()
+
         print("予測を開始します...")
         
         # モデルがml_assetsにロードされていない場合、または明示的にパスが指定された場合にロードを試みる
@@ -159,7 +178,9 @@ class MLDataset:
         with open(ml_dataset_storage.model_division_column, 'wb') as f:
             pickle.dump(self.model_division_column, f)
         with open(ml_dataset_storage.ml_assets, 'wb') as f:
-            pickle.dump(self.ml_assets, f) 
+            pickle.dump(self.ml_assets, f)
+        with open(ml_dataset_storage.preprocessing_config, 'wb') as f:
+            pickle.dump(self.preprocessing_config, f)
 
 
 @dataclass
@@ -204,3 +225,8 @@ class MLDatasetStorage:
     @property
     def ml_assets(self):
         return f'{self.base_path}/ml_assets.pickle'
+
+    @property
+    def preprocessing_config(self):
+        return f'{self.base_path}/preprocessing_config.pickle'
+

--- a/project/modules/machine_learning/ml_dataset/core/preprocessing_config.py
+++ b/project/modules/machine_learning/ml_dataset/core/preprocessing_config.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class PreprocessingConfig:
+    """前処理設定を管理するデータクラス"""
+    outlier_threshold: float = 0.0
+    no_shift_features: List[str] = field(default_factory=list)
+    remove_missing_data: bool = True

--- a/project/modules/machine_learning/ml_dataset/creators/ml_dataset_creator.py
+++ b/project/modules/machine_learning/ml_dataset/creators/ml_dataset_creator.py
@@ -6,8 +6,7 @@ from datetime import datetime
 import pickle
 
 from utils.timeseries import Duration
-from machine_learning.ml_dataset.core import MLDataset
-from machine_learning.ml_dataset.core import MLDatasetStorage
+from machine_learning.ml_dataset.core import MLDataset, MLDatasetStorage, PreprocessingConfig
 from machine_learning.ml_dataset.components import MachineLearningAsset
 
 # MLDataset, Duration, MachineLearningAssets は適切なパスからインポート
@@ -24,7 +23,8 @@ class MLDatasetCreator:
                test_duration: Duration,
                date_column: str,
                ml_asset: MachineLearningAsset,
-               model_division_column: Optional[str] = None) -> MLDataset:
+               model_division_column: Optional[str] = None,
+               preprocessing_config: PreprocessingConfig | None = None) -> MLDataset:
         """
         既存のDataFrameと期間情報からMLDatasetインスタンスを生成します。
         """
@@ -38,7 +38,8 @@ class MLDatasetCreator:
             test_duration=test_duration,
             date_column=date_column,
             model_division_column=model_division_column,
-            ml_assets=ml_asset
+            ml_assets=ml_asset,
+            preprocessing_config=preprocessing_config,
         )
 
     @staticmethod
@@ -58,7 +59,9 @@ class MLDatasetCreator:
         with open(ml_dataset_storage.model_division_column, 'rb') as f:
             model_division_column = pickle.load(f)
         with open(ml_dataset_storage.ml_assets, 'rb') as f:
-            ml_asset = pickle.load(f) 
+            ml_asset = pickle.load(f)
+        with open(ml_dataset_storage.preprocessing_config, 'rb') as f:
+            preprocessing_config = pickle.load(f)
         
         ml_dataset = MLDataset(
             dataset_path=dataset_path,
@@ -70,7 +73,8 @@ class MLDatasetCreator:
             test_duration=test_duration,
             date_column=date_column,
             model_division_column=model_division_column,
-            ml_assets=ml_asset
+            ml_assets=ml_asset,
+            preprocessing_config=preprocessing_config
         )
 
         return ml_dataset


### PR DESCRIPTION
## Summary
- add `PreprocessingConfig` dataclass
- add `MLDataPipeline` with preprocessing logic
- integrate pipeline into `MLDataset`
- export new classes in module init
- include `preprocessing_config` in creator save/load logic
- add `MachineLearningFacadeNew` facade to drive new dataset workflow
- restore dataframe generation in `MachineLearningFacadeNew`

## Testing
- `pytest -q` *(fails: pyenv missing)*

------
https://chatgpt.com/codex/tasks/task_e_68631ccc84208332815c245ee43488f7