### PR TITLE
Implement order merging for identical codes

### DIFF
--- a/project/modules/facades/data_pipeline/order_execution_facade.py
+++ b/project/modules/facades/data_pipeline/order_execution_facade.py
@@ -61,7 +61,10 @@ class OrderExecutionFacade:
                     orders_list.append(df)
 
             if orders_list:
-                return pd.concat(orders_list, ignore_index=True)
+                df = pd.concat(orders_list, ignore_index=True)
+                if 'Code' in df.columns:
+                    df = self._merge_same_codes(df)
+                return df
             return None
 
         if self.mode == "additional":
@@ -70,3 +73,42 @@ class OrderExecutionFacade:
             await self.trade_facade.settle_positions()
 
         return None
+
+    def _merge_same_codes(self, df: pd.DataFrame) -> pd.DataFrame:
+        """同一銘柄の注文を合算し1行にまとめる"""
+        df = df.copy()
+        duplicate_codes = df['Code'].duplicated(keep=False)
+        if not duplicate_codes.any():
+            df['CumCost_byLS'] = df['TotalCost'].cumsum()
+            return df
+
+        for code, group in df.groupby('Code'):
+            if len(group) == 1:
+                continue
+
+            long_sum = group.loc[group['Direction'] == 'Long', 'Unit'].sum()
+            short_sum = group.loc[group['Direction'] == 'Short', 'Unit'].sum()
+            x = long_sum - short_sum
+
+            keep_idx = group.index.min()
+            long_rows = group[group['Direction'] == 'Long']
+            base_row = long_rows.iloc[0] if not long_rows.empty else group.iloc[0]
+
+            if x == 0:
+                df = df.drop(group.index)
+                continue
+
+            df.loc[keep_idx, 'Direction'] = 'Long' if x > 0 else 'Short'
+            unit = x if x > 0 else -x
+            df.loc[keep_idx, 'Unit'] = unit
+            df.loc[keep_idx, 'UpperLimitCost'] = base_row['UpperLimitCost']
+            df.loc[keep_idx, 'isBorrowingStock'] = base_row.get('isBorrowingStock', False)
+            df.loc[keep_idx, 'TotalCost'] = unit * df.loc[keep_idx, 'EstimatedCost']
+            df.loc[keep_idx, 'UpperLimitTotal'] = unit * df.loc[keep_idx, 'UpperLimitCost']
+
+            drop_idx = [i for i in group.index if i != keep_idx]
+            df = df.drop(drop_idx)
+
+        df = df.sort_index().reset_index(drop=True)
+        df['CumCost_byLS'] = df['TotalCost'].cumsum()
+        return df


### PR DESCRIPTION
## Summary
- merge rows with identical `Code` values when executing new orders
- compute net position per code and recalc totals and cumulative cost

## Testing
- `python3 -m py_compile project/modules/facades/data_pipeline/order_execution_facade.py`


------
https://chatgpt.com/codex/tasks/task_e_6867839306488332b3351871ee695e5c