### PR TITLE
Refactor sector index and extract order price calculator

### DIFF
--- a/class_specs/calculation/sector_index/README.md
+++ b/class_specs/calculation/sector_index/README.md
@@ -11,7 +11,7 @@ Args:
     sector_redefinitions_csv (str): セクター再定義 CSV へのパス。
     sector_index_parquet (str): 計算結果を保存する parquet ファイルのパス。
 - _get_column_names: 
-- calc_sector_index: セクターインデックスを算出して ``order_price_df`` も返す。
+- calculate_sector_index: セクターインデックスを算出する。
 
 ``stock_dfs_dict`` で渡された株価データと財務データを用いて
 時価総額を計算し、CSV で指定されたセクター定義を結合して
@@ -19,29 +19,29 @@ Args:
 に保存される。
 
 Returns:
-    tuple[pd.DataFrame, pd.DataFrame]:
-        計算したセクターインデックスと発注処理用株価データ。
-- calc_sector_index_by_dict: 辞書形式のセクター定義からインデックスを計算する。
+    pd.DataFrame:
+        計算したセクターインデックス
+- calculate_sector_index_by_dict: 辞書形式のセクター定義からインデックスを計算する。
 
 Args:
     sector_stock_dict (dict):
         セクター名をキー、銘柄コードのリストを値とする辞書。
         例: ``{"JPY感応株": ["6758", "6501"], "JPbond感応株": ["6751", ...]}``
     stock_price_data (pd.DataFrame):
-        ``calc_marketcap`` の結果と同じ形式の株価データ。
+        ``calculate_marketcap`` の結果と同じ形式の株価データ。
 
 Returns:
     pd.DataFrame: セクターインデックスのデータフレーム。
 - get_sector_index_dict: セクター別のデータフレーム辞書を取得する。
 
-:meth:`calc_sector_index` が未実行の場合は内部で呼び出して
+:meth:`calculate_sector_index` が未実行の場合は内部で呼び出して
 計算結果をキャッシュする。
 
 Returns
 -------
-tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame]]
-    セクターインデックスと発注処理用の価格データを、それぞれセクター別に分割した辞書を返す。
-- calc_marketcap: 各銘柄の日次時価総額を計算する。
+dict[str, pd.DataFrame]
+    セクターインデックスをセクター別に分割した辞書を返す。
+- calculate_marketcap: 各銘柄の日次時価総額を計算する。
 
 Args:
     stock_price (pd.DataFrame): 株価データ。

--- a/project/execution_scripts/current_files/deeplearning_test.py
+++ b/project/execution_scripts/current_files/deeplearning_test.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from utils.paths import Paths #パス一覧
 from acquisition.jquants_api_operations import run_jquants_api_operations
-from calculation import SectorIndex
+from calculation import SectorIndex, OrderPriceCalculator
 from models import MLDataset
 import asyncio
 
@@ -43,7 +43,9 @@ async def main(ML_DATASET_PATH:str, NEW_SECTOR_LIST_CSV:str, NEW_SECTOR_PRICE_PK
     stock_dfs_dict = {'list': list_df, 'fin': fin_df, 'price': price_df}
 
     sic = SectorIndex()
-    new_sector_price_df, order_price_df = sic.calc_sector_index(stock_dfs_dict, NEW_SECTOR_LIST_CSV, NEW_SECTOR_PRICE_PKLGZ)
+    new_sector_price_df = sic.calculate_sector_index(stock_dfs_dict, NEW_SECTOR_LIST_CSV, NEW_SECTOR_PRICE_PKLGZ)
+    opc = OrderPriceCalculator()
+    order_price_df = opc.calculate_order_price(stock_dfs_dict['price'], stock_dfs_dict['fin'], sic._get_column_names)
 
     '''リターン予測→ml_datasetの作成'''
     import torch

--- a/project/execution_scripts/current_files/feature_calc_new.py
+++ b/project/execution_scripts/current_files/feature_calc_new.py
@@ -11,8 +11,11 @@ SECTOR_REDEFINITIONS_CSV = f'{Paths.SECTOR_REDEFINITIONS_FOLDER}/48sectors_2024-
 SECTOR_INDEX_PARQUET = f'{Paths.SECTOR_PRICE_FOLDER}/New48sectors_price.parquet'
 
 from calculation.sector_index.sector_index import SectorIndex
+from calculation.order_price_calculator import OrderPriceCalculator
 sic = SectorIndex(stock_dfs, SECTOR_REDEFINITIONS_CSV, SECTOR_INDEX_PARQUET)
-sector_df, order_price_df = sic.calc_sector_index()
+sector_df = sic.calculate_sector_index()
+opc = OrderPriceCalculator()
+order_price_df = opc.calculate_order_price(stock_dfs['price'], stock_dfs['fin'], sic._get_column_names)
 
 
 print(sector_df)

--- a/project/modules/calculation/__init__.py
+++ b/project/modules/calculation/__init__.py
@@ -1,6 +1,7 @@
 from .target import TargetCalculator
 from .features_calculator import FeaturesCalculator
 from .sector_index import SectorIndex
+from .order_price_calculator import OrderPriceCalculator
 from .sector_fin_calculator import SectorFinCalculator
 from .features import FeaturesSet
 
@@ -8,6 +9,7 @@ __all__ = [
     'TargetCalculator',
     'FeaturesCalculator',
     'SectorIndex',
+    'OrderPriceCalculator',
     'SectorFinCalculator',
     'FeaturesSet'
 ]

--- a/project/modules/calculation/facades/calculator_facade.py
+++ b/project/modules/calculation/facades/calculator_facade.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from typing import Literal, Optional, Tuple
 from calculation.sector_index.sector_index import SectorIndex
+from calculation.order_price_calculator import OrderPriceCalculator
 from calculation.features_calculator import FeaturesCalculator
 from preprocessing.pipeline import PreprocessingPipeline
 
@@ -75,10 +76,16 @@ class CalculatorFacade:
         
         # 1. セクターインデックスの計算
         sic = SectorIndex()
-        new_sector_price, order_price_df = sic.calc_sector_index(
+        new_sector_price = sic.calculate_sector_index(
             stock_dfs_dict=stock_dfs,
             SECTOR_REDEFINITIONS_CSV=sector_redefinitions_csv,
             SECTOR_INDEX_PARQUET=sector_index_parquet
+        )
+        opc = OrderPriceCalculator()
+        order_price_df = opc.calculate_order_price(
+            stock_dfs['price'],
+            stock_dfs['fin'],
+            sic._get_column_names,
         )
         
         # 2. セクター定義の読み込み（特徴量計算用）

--- a/project/modules/calculation/features/facades/features_facade.py
+++ b/project/modules/calculation/features/facades/features_facade.py
@@ -126,7 +126,7 @@ class FeaturesFacade:
         """セクターデータの準備"""
         print("セクターデータを準備中...")
         sic = SectorIndex()
-        sector_df, _ = sic.calc_sector_index(
+        sector_df = sic.calculate_sector_index(
             stock_dfs_dict, sector_redefinitions_csv, sector_index_parquet
         )
         sector_list_df = pd.read_csv(sector_redefinitions_csv)

--- a/project/modules/calculation/features/implementation/price_features.py
+++ b/project/modules/calculation/features/implementation/price_features.py
@@ -142,7 +142,7 @@ class PriceFeatures(BaseFeatures):
 
         new_sector_list['Code'] = new_sector_list['Code'].astype(str)
         sic = SectorIndex()
-        stock_price_cap = sic.calc_marketcap(
+        stock_price_cap = sic.calculate_marketcap(
             stock_dfs_dict['price'], stock_dfs_dict['fin']
         )
         

--- a/project/modules/calculation/features/integration/features_set.py
+++ b/project/modules/calculation/features/integration/features_set.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     saf = StockAcquisitionFacade(filter="(Listing==1)&((ScaleCategory=='TOPIX Core30')|(ScaleCategory=='TOPIX Large70')|(ScaleCategory=='TOPIX Mid400'))")
     stock_dfs = saf.get_stock_data_dict()
     sic = SectorIndex()
-    sector_df, _ = sic.calc_sector_index(stock_dfs, SECTOR_REDEFINITIONS_CSV, SECTOR_INDEX_PARQUET)
+    sector_df = sic.calculate_sector_index(stock_dfs, SECTOR_REDEFINITIONS_CSV, SECTOR_INDEX_PARQUET)
     sector_list_df = pd.read_csv(SECTOR_REDEFINITIONS_CSV)
 
     i_features = IndexFeatures()

--- a/project/modules/calculation/order_price_calculator.py
+++ b/project/modules/calculation/order_price_calculator.py
@@ -1,0 +1,65 @@
+from typing import Callable, Dict
+import pandas as pd
+
+from .sector_index.calculators.marketcap_calculator import MarketCapCalculator
+from .sector_index.preparers.sector_data_preparer import SectorDataPreparer
+
+
+class OrderPriceCalculator:
+    """発注用株価データを計算するクラス。"""
+
+    def __init__(self) -> None:
+        self._marketcap_calc = MarketCapCalculator()
+        self._data_preparer = SectorDataPreparer()
+
+    def calculate_order_price(
+        self,
+        stock_price: pd.DataFrame,
+        stock_fin: pd.DataFrame,
+        col_getter: Callable,
+    ) -> pd.DataFrame:
+        """発注処理用の株価データを計算して返す。"""
+        stock_price_with_shares = self._marketcap_calc.merge_stock_price_and_shares(
+            stock_price, stock_fin, col_getter
+        )
+        stock_price_cap = self._marketcap_calc.calc_adjustment_factor(
+            stock_price_with_shares, stock_price, col_getter
+        )
+        stock_price_cap = self._marketcap_calc.adjust_shares(stock_price_cap, col_getter)
+        stock_price_cap = self._marketcap_calc.calc_marketcap(stock_price_cap, col_getter)
+        stock_price_cap = self._marketcap_calc.calc_correction_value(
+            stock_price_cap, col_getter
+        )
+
+        _, price_col, sector_col = col_getter()
+        return stock_price_cap[[
+            sector_col['日付'],
+            sector_col['銘柄コード'],
+            sector_col['終値時価総額'],
+            sector_col['終値'],
+            price_col['取引高'],
+        ]]
+
+    def get_order_price_dict(
+        self,
+        order_price_df: pd.DataFrame,
+        sector_redefinitions_csv: str,
+        col_getter: Callable,
+    ) -> Dict[str, pd.DataFrame]:
+        """セクター別に分割した発注処理用株価データを返す。"""
+        order_price_data = self._data_preparer.from_csv(
+            order_price_df,
+            sector_redefinitions_csv,
+            col_getter,
+        )
+        _, _, sector_col = col_getter()
+        date_name = sector_col['日付']
+        sector_name = sector_col['セクター']
+        code_name = sector_col['銘柄コード']
+
+        order_dict: Dict[str, pd.DataFrame] = {}
+        for sec in order_price_data[sector_name].unique():
+            df = order_price_data[order_price_data[sector_name] == sec].copy()
+            df = df.set_index([date_name, code_name])
+            order_dict[sec] = df
+        return order_dict

--- a/project/modules/facades/data_pipeline/lasso_learning_facade.py
+++ b/project/modules/facades/data_pipeline/lasso_learning_facade.py
@@ -5,7 +5,7 @@ import pandas as pd
 import os
 from datetime import datetime
 
-from calculation import SectorIndex, TargetCalculator, FeaturesCalculator
+from calculation import SectorIndex, OrderPriceCalculator, TargetCalculator, FeaturesCalculator
 #from machine_learning.ml_dataset.core import MLDataset
 from machine_learning.ml_dataset import MLDataset
 from machine_learning.models import LassoTrainer
@@ -73,7 +73,13 @@ class LassoLearningFacade:
 
     def _get_necessary_dfs(self):
         sic = SectorIndex(self.stock_dfs_dict, self.sector_redef_csv_path, self.sector_index_parquet_path)
-        new_sector_price_df, order_price_df = sic.calc_sector_index()
+        new_sector_price_df = sic.calculate_sector_index()
+        opc = OrderPriceCalculator()
+        order_price_df = opc.calculate_order_price(
+            self.stock_dfs_dict['price'],
+            self.stock_dfs_dict['fin'],
+            sic._get_column_names,
+        )
         raw_returns_df, target_df = TargetCalculator.daytime_return_PCAresiduals(
             new_sector_price_df,
             reduce_components=1,

--- a/project/modules/facades/data_pipeline/subseq_lgbm_learning_facade.py
+++ b/project/modules/facades/data_pipeline/subseq_lgbm_learning_facade.py
@@ -5,7 +5,7 @@ import pandas as pd
 import os
 from datetime import datetime
 
-from calculation import SectorIndex, TargetCalculator, FeaturesCalculator
+from calculation import SectorIndex, OrderPriceCalculator, TargetCalculator, FeaturesCalculator
 from machine_learning.ml_dataset import MLDataset
 from machine_learning.models import LgbmTrainer
 from utils.notifier import SlackNotifier
@@ -77,7 +77,13 @@ class SubseqLgbmLearningFacade:
 
     def _get_necessary_dfs(self):
         sic = SectorIndex(self.stock_dfs_dict, self.sector_redef_csv_path, self.sector_index_parquet_path)
-        new_sector_price_df, order_price_df = sic.calc_sector_index()
+        new_sector_price_df = sic.calculate_sector_index()
+        opc = OrderPriceCalculator()
+        order_price_df = opc.calculate_order_price(
+            self.stock_dfs_dict['price'],
+            self.stock_dfs_dict['fin'],
+            sic._get_column_names,
+        )
         raw_returns_df, target_df = TargetCalculator.daytime_return_PCAresiduals(
             new_sector_price_df,
             reduce_components=1,


### PR DESCRIPTION
## Summary
- refactor `SectorIndex` to rename calculate functions and return only sector index
- add new `OrderPriceCalculator` class
- adapt facades and features calculators to use `OrderPriceCalculator`
- update documentation and example scripts

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68693d41fc748332af7626b4f64de609