### PR TITLE
Update Pc1RemovedIntradayReturn imports

### DIFF
--- a/class_specs/calculation/target/README.md
+++ b/class_specs/calculation/target/README.md
@@ -60,7 +60,10 @@ Args:
     df (pd.DataFrame): 元データ（Open, Closeの各列が必須）
 Returns:
     pd.DataFrame: 日中リターン（Target列）を含むDataFrame
-- daytime_return_PCAresiduals: PCAで主成分を除去した日中リターンの残差を算出。
-Returns:
-    tuple[pd.DataFrame, pd.DataFrame]: 生の日中リターン, PCA残差リターン
+
+### class Pc1RemovedIntradayReturn
+PC1 を除去した日内リターンを計算するファサード。
+ - `calculate(fit_duration: Duration)`: PCA の学習期間を指定して計算を実行。
+ - `processed_return`: PCA 適用後のリターンを取得。
+ - `raw_return`: PCA 適用前の生リターンを取得。
 

--- a/project/modules/facades/data_pipeline/subseq_lgbm_learning_facade.py
+++ b/project/modules/facades/data_pipeline/subseq_lgbm_learning_facade.py
@@ -5,7 +5,8 @@ import pandas as pd
 import os
 from datetime import datetime
 
-from calculation import SectorIndex, TargetCalculator, FeaturesCalculator
+from calculation import SectorIndex, FeaturesCalculator
+from timeseries_data.facades import Pc1RemovedIntradayReturn
 from machine_learning.ml_dataset import MLDataset
 from machine_learning.models import LgbmTrainer
 from utils.notifier import SlackNotifier
@@ -78,11 +79,10 @@ class SubseqLgbmLearningFacade:
     def _get_necessary_dfs(self):
         sic = SectorIndex(self.stock_dfs_dict, self.sector_redef_csv_path, self.sector_index_parquet_path)
         new_sector_price_df, order_price_df = sic.calc_sector_index()
-        raw_returns_df, target_df = TargetCalculator.daytime_return_PCAresiduals(
-            new_sector_price_df,
-            reduce_components=1,
-            train_duration=self.train_duration,
-        )
+        pc1_return = Pc1RemovedIntradayReturn(original_timeseries=new_sector_price_df)
+        pc1_return.calculate(fit_duration=self.train_duration)
+        raw_returns_df = pc1_return.raw_return
+        target_df = pc1_return.processed_return
         self.target_df = target_df
         self.raw_returns_df = raw_returns_df
         self.order_price_df = order_price_df

--- a/project/modules/timeseries_data/facades/__init__.py
+++ b/project/modules/timeseries_data/facades/__init__.py
@@ -1,0 +1,1 @@
+from .pc1_removed_intraday_return import Pc1RemovedIntradayReturn


### PR DESCRIPTION
## Summary
- import `Pc1RemovedIntradayReturn` from package root
- restore TargetCalculator debug example

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fecaab9548332a34096d155e89796