### PR TITLE
Add BondDailyReturnBase

### DIFF
--- a/project/modules/timeseries_data/calculation_method/__init__.py
+++ b/project/modules/timeseries_data/calculation_method/__init__.py
@@ -2,3 +2,4 @@ from .base import CalculationMethodBase
 from .intraday_return import IntradayReturn
 from .overnight_return import OvernightReturn
 from .daily_return import DailyReturn
+from .bond_daily_return_base import BondDailyReturnBase

--- a/project/modules/timeseries_data/calculation_method/bond_daily_return_base.py
+++ b/project/modules/timeseries_data/calculation_method/bond_daily_return_base.py
@@ -1,0 +1,22 @@
+from timeseries_data.calculation_method.base import CalculationMethodBase
+import pandas as pd
+
+class BondDailyReturnBase(CalculationMethodBase):
+    """債券利回りの日次変化量を計算する基底クラス"""
+
+    def __init__(self, return_column: str = 'Target', close_column: str = 'Close'):
+        """
+        Args:
+            return_column (str): 返り値のカラム名
+            close_column (str): 終値のカラム名
+        """
+        self._return_column = return_column
+        self._close_column = close_column
+
+    def calculate(self, return_timeseries: pd.DataFrame) -> pd.DataFrame:
+        """当日終値と前日終値の差分でリターンを計算します。"""
+        result_df = return_timeseries.copy()
+        result_df[self._return_column] = (
+            return_timeseries[self._close_column] - return_timeseries[self._close_column].shift(1)
+        )
+        return result_df[[self._return_column]]


### PR DESCRIPTION
## Summary
- implement `BondDailyReturnBase` to compute bond return as close difference
- expose `BondDailyReturnBase` via `timeseries_data.calculation_method`

## Testing
- `pytest -q` *(fails: pyenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870f83a3bd08332b831c40b5436c53e